### PR TITLE
pointing API pages to the pages on docs.delta.io, add contribute link…

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -182,6 +182,11 @@ export default defineConfig({
           label: "Delta table properties reference",
           link: "/latest/table-properties/",
         },
+        {
+          label: "Contribute",
+          link: "https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md",
+          attrs: { target: "_blank" },
+        },
       ],
     }),
   ],

--- a/src/content/docs/latest/apache-spark-connector/change-data-feed/index.mdx
+++ b/src/content/docs/latest/apache-spark-connector/change-data-feed/index.mdx
@@ -6,8 +6,6 @@ description: Learn how to use the Change Data Feed (CDF) feature to track row-le
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 import { Code, Aside } from "@astrojs/starlight/components";
 
-## Change data feed
-
 Change Data Feed (CDF) feature allows Delta tables to track row-level changes between versions of a Delta table. When enabled on a Delta table, the runtime records "change events" for all the data written into the table. This includes the row data along with metadata indicating whether the specified row was inserted, deleted, or updated.
 
 You can read the change events in batch queries using DataFrame APIs (that is, `df.read`) and in streaming queries using DataFrame APIs (that is, `df.readStream`).

--- a/src/content/docs/latest/apache-spark-connector/constraints/index.mdx
+++ b/src/content/docs/latest/apache-spark-connector/constraints/index.mdx
@@ -6,8 +6,6 @@ description: Learn how to use constraints in Delta Lake tables to ensure data qu
 import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 import { Code } from "@astrojs/starlight/components";
 
-## Constraints
-
 Delta tables support standard SQL constraint management clauses that ensure that the quality and integrity of data added to a table is automatically verified. When a constraint is violated, Delta Lake throws an `InvariantViolationException` to signal that the new data can't be added.
 
 <Aside

--- a/src/content/docs/latest/apache-spark-connector/delta-column-mapping/index.mdx
+++ b/src/content/docs/latest/apache-spark-connector/delta-column-mapping/index.mdx
@@ -106,4 +106,3 @@ as any of these characters in the table's column names: `,;{}()\n\t=`.
   [Tracking non-additive schema changes](/latest/apache-spark-connector/table-streaming-reads-and-writes/#schema-tracking)
 - The Delta table protocol specifies two modes of column mapping, by `name` and
   by `id`. Delta Lake 2.1 and below do not support `id` mode.
-```

--- a/src/content/docs/latest/delta-lake-apis/index.mdx
+++ b/src/content/docs/latest/delta-lake-apis/index.mdx
@@ -11,13 +11,13 @@ Some Delta Lake APIs are still evolving and are indicated with the **Evolving** 
 
 ## Delta Spark
 
-Delta Spark is a library for reading and writing Delta tables using Apache Spark™. For most read and write operations on Delta tables, you can use Apache Spark [reader and writer](/spark/latest/dataframes-datasets/index.md) APIs. For examples, see [\_](delta-batch.md) and [\_](delta-streaming.md).
+Delta Spark is a library for reading and writing Delta tables using Apache Spark™. For most read and write operations on Delta tables, you can use Apache Spark reader and writer APIs. For examples, see [Table batch reads and writes](/latest/apache-spark-connector/table-batch-reads-and-writes/) and [Table streaming reads and writes](/latest/apache-spark-connector/table-streaming-reads-and-writes/).
 
-However, there are some operations that are specific to Delta Lake and you must use Delta Lake APIs. For examples, see [\_](delta-utility.md).
+However, there are some operations that are specific to Delta Lake and you must use Delta Lake APIs. For examples, see [Table utility commands](/latest/apache-spark-connector/table-utility-commands/).
 
-- [Scala API docs](api/scala/spark/io/delta/tables/index.html)
-- [Java API docs](api/java/spark/index.html)
-- [Python API docs](api/python/spark/index.html)
+- [Scala API docs](https://docs.delta.io/latest/api/scala/spark/io/delta/tables/index.html)
+- [Java API docs](https://docs.delta.io/latest/api/java/spark/index.html)
+- [Python API docs](https://docs.delta.io/latest/api/python/spark/index.html)
 
 ## Delta Kernel
 
@@ -28,7 +28,7 @@ Delta Kernel is a library for operating on Delta tables. Specifically, it provid
 
 More details refer [here](https://github.com/delta-io/delta/blob/branch-3.0/kernel/USER_GUIDE.md).
 
-- [Java API docs](api/java/kernel/index.html)
+- [Java API docs](https://docs.delta.io/latest/api/java/kernel/index.html)
 
 ## Delta Rust
 
@@ -36,14 +36,16 @@ This [library](https://docs.rs/deltalake/latest/deltalake/) allows Rust (with Py
 
 ## Delta Standalone
 
-:::danger[Warning!] The Delta Standalone is deprecated in favor of [Delta Kernel](delta-kernel.md) which has support for reading from or writing into Delta tables with advanced features. :::
+<Aside type="caution">
+The Delta Standalone is deprecated in favor of [Delta Kernel](/latest/delta-kernel/) which has support for reading from or writing into Delta tables with advanced features.
+</Aside>
 
 Delta Standalone, formerly known as the Delta Standalone Reader (DSR), is a JVM library to read and write Delta tables. Unlike Delta-Spark, this library doesn't use Spark to read or write tables and it has only a few transitive dependencies. It can be used by any application that cannot use a Spark cluster. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/README.md).
 
-- [Java API docs](api/java/standalone/index.html)
+- [Java API docs](https://docs.delta.io/latest/api/java/standalone/index.html)
 
 ## Delta Flink
 
 Flink/Delta Connector is a JVM library to read and write data from Apache Flink applications to Delta tables utilizing the Delta Standalone JVM library. More details refer [here](https://github.com/delta-io/delta/blob/master/connectors/flink/README.md).
 
-- [Java API docs](api/java/flink/index.html)
+- [Java API docs](https://docs.delta.io/latest/api/java/flink/index.html)


### PR DESCRIPTION
## What changed?

pointing API pages to the pages on docs.delta.io, add contribute link

## Screenshot
