### PR TITLE
Sync v4 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> [!NOTE] The content in this repo is currently in sync with delta-io/delta@5d40e1829f4f5cb00686e24f7e0bbc94aad5e93b
+
 # Delta Docs
 
 This folder contains all of the source code needed to generate the delta documentation site.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
     "/delta-deletion-vectors.html": "/delta-deletion-vectors",
     "/delta-drop-feature.html": "/delta-drop-feature",
     "/delta-row-tracking.html": "/delta-row-tracking",
+    "/delta-spark-connect.html": "/delta-spark-connect",
     "/delta-storage.html": "/delta-storage",
     "/delta-type-widening.html": "/delta-type-widening",
     "/delta-uniform.html": "/delta-uniform",
@@ -123,6 +124,9 @@ export default defineConfig({
             },
             {
               slug: "delta-row-tracking",
+            },
+            {
+              slug: "delta-spark-connect",
             },
             {
               slug: "delta-storage",

--- a/src/content/docs/delta-apidoc.mdx
+++ b/src/content/docs/delta-apidoc.mdx
@@ -3,8 +3,7 @@ title: Delta Lake APIs
 description: Learn about the APIs provided by Delta Lake.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Aside type="note">
   Some Delta Lake APIs are still evolving and are indicated with the

--- a/src/content/docs/delta-apidoc.mdx
+++ b/src/content/docs/delta-apidoc.mdx
@@ -3,7 +3,7 @@ title: Delta Lake APIs
 description: Learn about the APIs provided by Delta Lake.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
 
 <Aside type="note">
   Some Delta Lake APIs are still evolving and are indicated with the

--- a/src/content/docs/delta-batch.mdx
+++ b/src/content/docs/delta-batch.mdx
@@ -3,7 +3,7 @@ title: Table batch reads and writes
 description: Learn how to perform batch reads and writes on Delta tables.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta Lake supports most of the options provided by Apache Spark DataFrame read and write APIs for performing batch reads and writes on tables.
 

--- a/src/content/docs/delta-batch.mdx
+++ b/src/content/docs/delta-batch.mdx
@@ -16,118 +16,174 @@ Delta Lake supports creating two types of tables—tables defined in the metasto
 
 To work with metastore-defined tables, you must enable integration with Apache Spark DataSourceV2 and Catalog APIs by setting configurations when you create a new `SparkSession`. See [Configure SparkSession](#configure-sparksession).
 
-You can create tables in the following ways.
+You can create tables in the following ways:
 
 - **SQL DDL commands**: You can use standard SQL DDL commands supported in Apache Spark (for example, `CREATE TABLE` and `REPLACE TABLE`) to create Delta tables.
 
-```sql
-CREATE TABLE IF NOT EXISTS default.people10m (
-  id INT,
-  firstName STRING,
-  middleName STRING,
-  lastName STRING,
-  gender STRING,
-  birthDate TIMESTAMP,
-  ssn STRING,
-  salary INT
-) USING DELTA
+    <Tabs syncKey="code-examples">
+      <TabItem label="SQL" active>
 
-CREATE OR REPLACE TABLE default.people10m (
-  id INT,
-  firstName STRING,
-  middleName STRING,
-  lastName STRING,
-  gender STRING,
-  birthDate TIMESTAMP,
-  ssn STRING,
-  salary INT
-) USING DELTA
-```
+        ```sql
+        CREATE TABLE IF NOT EXISTS default.people10m (
+          id INT,
+          firstName STRING,
+          middleName STRING,
+          lastName STRING,
+          gender STRING,
+          birthDate TIMESTAMP,
+          ssn STRING,
+          salary INT
+        ) USING DELTA
 
-SQL also supports creating a table at a path, without creating an entry in the Hive metastore.
+        CREATE OR REPLACE TABLE default.people10m (
+          id INT,
+          firstName STRING,
+          middleName STRING,
+          lastName STRING,
+          gender STRING,
+          birthDate TIMESTAMP,
+          ssn STRING,
+          salary INT
+        ) USING DELTA
+        ```
+      
+      </TabItem>
+    </Tabs>
 
-```sql
--- Create or replace table with path
-CREATE OR REPLACE TABLE delta.`/tmp/delta/people10m` (
-  id INT,
-  firstName STRING,
-  middleName STRING,
-  lastName STRING,
-  gender STRING,
-  birthDate TIMESTAMP,
-  ssn STRING,
-  salary INT
-) USING DELTA
-```
+    SQL also supports creating a table at a path, without creating an entry in the Hive metastore.
+
+    <Tabs syncKey="code-examples">
+      <TabItem label="SQL" active>
+
+        ```sql
+        -- Create or replace table with path
+        CREATE OR REPLACE TABLE delta.`/tmp/delta/people10m` (
+          id INT,
+          firstName STRING,
+          middleName STRING,
+          lastName STRING,
+          gender STRING,
+          birthDate TIMESTAMP,
+          ssn STRING,
+          salary INT
+        ) USING DELTA
+        ```
+      
+      </TabItem>
+    </Tabs>
 
 - **`DataFrameWriter` API**: If you want to simultaneously create a table and insert data into it from Spark DataFrames or Datasets, you can use the Spark `DataFrameWriter` ([Scala or Java](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameWriter.html) and [Python](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/io.html)).
 
-<Tabs syncKey="code-examples">
-  <TabItem label="Python">
+    <Tabs syncKey="code-examples">
+      <TabItem label="Python">
 
-    ```python
-    # Create table in the metastore using DataFrame's schema and write data to it
-    df.write.format("delta").saveAsTable("default.people10m")
+        ```python
+        # Create table in the metastore using DataFrame's schema and write data to it
+        df.write.format("delta").saveAsTable("default.people10m")
 
-    # Create or replace partitioned table with path using DataFrame's schema and write/overwrite data to it
-    df.write.format("delta").mode("overwrite").save("/tmp/delta/people10m")
-    ```
+        # Create or replace partitioned table with path using DataFrame's schema and write/overwrite data to it
+        df.write.format("delta").mode("overwrite").save("/tmp/delta/people10m")
+        ```
 
-  </TabItem>
-  <TabItem label="Scala">
+      </TabItem>
+      <TabItem label="Scala">
 
-    ```scala
-    // Create table in the metastore using DataFrame's schema and write data to it
-    df.write.format("delta").saveAsTable("default.people10m")
+        ```scala
+        // Create table in the metastore using DataFrame's schema and write data to it
+        df.write.format("delta").saveAsTable("default.people10m")
 
-    // Create table with path using DataFrame's schema and write data to it
-    df.write.format("delta").mode("overwrite").save("/tmp/delta/people10m")
-    ```
+        // Create table with path using DataFrame's schema and write data to it
+        df.write.format("delta").mode("overwrite").save("/tmp/delta/people10m")
+        ```
 
-  </TabItem>
-</Tabs>
+      </TabItem>
+    </Tabs>
 
-You can also create Delta tables using the Spark `DataFrameWriterV2` API.
+    You can also create Delta tables using the Spark `DataFrameWriterV2` API.
 
 - **`DeltaTableBuilder` API**: You can also use the `DeltaTableBuilder` API in Delta Lake to create tables. Compared to the DataFrameWriter APIs, this API makes it easier to specify additional information like column comments, table properties, and [generated columns](#use-generated-columns).
 
-<Tabs syncKey="code-examples">
-  <TabItem label="Python">
-    ```python
-    DeltaTable.createIfNotExists(spark) \
-      .tableName("default.people10m") \
-      .addColumn("id", "INT") \
-      .addColumn("firstName", "STRING") \
-      .addColumn("middleName", "STRING") \
-      .addColumn("lastName", "STRING", comment = "surname") \
-      .addColumn("gender", "STRING") \
-      .addColumn("birthDate", "TIMESTAMP") \
-      .addColumn("ssn", "STRING") \
-      .addColumn("salary", "INT") \
-      .execute()
-    ```
-  </TabItem>
-  <TabItem label="Scala">
-    ```scala
-    DeltaTable.createOrReplace(spark)
-      .tableName("default.people10m")
-      .addColumn("id", "INT")
-      .addColumn("firstName", "STRING")
-      .addColumn("middleName", "STRING")
-      .addColumn(
-        DeltaTable.columnBuilder("lastName")
-          .dataType("STRING")
-          .comment("surname")
-          .build())
-      .addColumn("lastName", "STRING", comment = "surname")
-      .addColumn("gender", "STRING")
-      .addColumn("birthDate", "TIMESTAMP")
-      .addColumn("ssn", "STRING")
-      .addColumn("salary", "INT")
-      .execute()
-    ```
-  </TabItem>
-</Tabs>
+    <Aside type="note">
+
+      This feature is new and is in Preview.
+
+      <Tabs syncKey="code-examples">
+        <TabItem label="Python">
+          
+          ```python
+          # Create table in the metastore
+          DeltaTable.createIfNotExists(spark) \
+            .tableName("default.people10m") \
+            .addColumn("id", "INT") \
+            .addColumn("firstName", "STRING") \
+            .addColumn("middleName", "STRING") \
+            .addColumn("lastName", "STRING", comment = "surname") \
+            .addColumn("gender", "STRING") \
+            .addColumn("birthDate", "TIMESTAMP") \
+            .addColumn("ssn", "STRING") \
+            .addColumn("salary", "INT") \
+            .execute()
+
+          # Create or replace table with path and add properties
+          DeltaTable.createOrReplace(spark) \
+            .addColumn("id", "INT") \
+            .addColumn("firstName", "STRING") \
+            .addColumn("middleName", "STRING") \
+            .addColumn("lastName", "STRING", comment = "surname") \
+            .addColumn("gender", "STRING") \
+            .addColumn("birthDate", "TIMESTAMP") \
+            .addColumn("ssn", "STRING") \
+            .addColumn("salary", "INT") \
+            .property("description", "table with people data") \
+            .location("/tmp/delta/people10m") \
+            .execute()
+          ```
+
+        </TabItem>
+        <TabItem label="Scala">
+
+          ```scala
+          // Create table in the metastore
+          DeltaTable.createOrReplace(spark)
+            .tableName("default.people10m")
+            .addColumn("id", "INT")
+            .addColumn("firstName", "STRING")
+            .addColumn("middleName", "STRING")
+            .addColumn(
+              DeltaTable.columnBuilder("lastName")
+                .dataType("STRING")
+                .comment("surname")
+                .build())
+            .addColumn("lastName", "STRING", comment = "surname")
+            .addColumn("gender", "STRING")
+            .addColumn("birthDate", "TIMESTAMP")
+            .addColumn("ssn", "STRING")
+            .addColumn("salary", "INT")
+            .execute()
+
+          // Create or replace table with path and add properties
+          DeltaTable.createOrReplace(spark)
+            .addColumn("id", "INT")
+            .addColumn("firstName", "STRING")
+            .addColumn("middleName", "STRING")
+            .addColumn(
+              DeltaTable.columnBuilder("lastName")
+                .dataType("STRING")
+                .comment("surname")
+                .build())
+            .addColumn("lastName", "STRING", comment = "surname")
+            .addColumn("gender", "STRING")
+            .addColumn("birthDate", "TIMESTAMP")
+            .addColumn("ssn", "STRING")
+            .addColumn("salary", "INT")
+            .property("description", "table with people data")
+            .location("/tmp/delta/people10m")
+            .execute()
+          ```
+
+        </TabItem>
+      </Tabs>
+    </Aside>
 
 See the [API documentation](/delta-apidoc/) for details.
 
@@ -206,22 +262,25 @@ To determine whether a table contains a specific partition, use the statement `S
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
+
     ```sql
-    SELECT COUNT(*) > 0 AS `Partition exists` FROM default.people10m
-    WHERE gender = "M"
+    SELECT COUNT(*) > 0 AS `Partition exists` FROM default.people10m WHERE gender = "M"
     ```
+
   </TabItem>
   <TabItem label="Python">
+
     ```python
-    display(spark.sql("SELECT COUNT(*) > 0 AS `Partition exists` FROM
-    default.people10m WHERE gender = 'M'"))
+    display(spark.sql("SELECT COUNT(*) > 0 AS `Partition exists` FROM default.people10m WHERE gender = 'M'"))
     ```
+
   </TabItem>
   <TabItem label="Scala">
+
     ```scala
-    display(spark.sql("SELECT COUNT(*) > 0 AS `Partition exists` FROM
-    default.people10m WHERE gender = 'M'"))
+    display(spark.sql("SELECT COUNT(*) > 0 AS `Partition exists` FROM default.people10m WHERE gender = 'M'"))
     ```
+
   </TabItem>
 </Tabs>
 
@@ -233,11 +292,17 @@ When you run `CREATE TABLE` with a `LOCATION` that _already_ contains data store
 
 - If you specify _only the table name and location_, for example:
 
-  ```sql
-  CREATE TABLE default.people10m
-  USING DELTA
-  LOCATION '/tmp/delta/people10m'
-  ```
+  <Tabs syncKey="code-examples">
+    <TabItem label="SQL" active>
+
+      ```sql
+      CREATE TABLE default.people10m
+      USING DELTA
+      LOCATION '/tmp/delta/people10m'
+      ```
+    
+    </TabItem>
+  </Tabs>
 
   the table in the metastore automatically inherits the schema, partitioning, and table properties of the existing data. This functionality can be used to "import" data into the metastore.
 
@@ -349,52 +414,76 @@ Delta Lake may be able to generate partition filters for a query whenever a part
 - Four partition columns defined by `YEAR(col), MONTH(col), DAY(col), HOUR(col)` and the type of `col` is `TIMESTAMP`.
 - `SUBSTRING(col, pos, len)` and the type of `col` is `STRING`
 - `DATE_FORMAT(col, format)` and the type of `col` is `TIMESTAMP`.
-- `DATE_TRUNC(format, col) and the type of the `col`is`TIMESTAMP`or`DATE`.
+- `DATE_TRUNC(format, col)` and the type of the `col` is `TIMESTAMP` or `DATE`.
 - `TRUNC(col, format)` and type of the `col` is either `TIMESTAMP` or `DATE`.
 
 If a partition column is defined by one of the preceding expressions, and a query filters data using the underlying base column of a generation expression, Delta Lake looks at the relationship between the base column and the generated column, and populates partition filters based on the generated partition column if possible. For example, given the following table:
 
-```python
-DeltaTable.create(spark) \
-  .tableName("default.events") \
-  .addColumn("eventId", "BIGINT") \
-  .addColumn("data", "STRING") \
-  .addColumn("eventType", "STRING") \
-  .addColumn("eventTime", "TIMESTAMP") \
-  .addColumn("eventDate", "DATE", generatedAlwaysAs="CAST(eventTime AS DATE)") \
-  .partitionedBy("eventType", "eventDate") \
-  .execute()
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    DeltaTable.create(spark) \
+      .tableName("default.events") \
+      .addColumn("eventId", "BIGINT") \
+      .addColumn("data", "STRING") \
+      .addColumn("eventType", "STRING") \
+      .addColumn("eventTime", "TIMESTAMP") \
+      .addColumn("eventDate", "DATE", generatedAlwaysAs="CAST(eventTime AS DATE)") \
+      .partitionedBy("eventType", "eventDate") \
+      .execute()
+    ```
+  
+  </TabItem>
+</Tabs>
 
 If you then run the following query:
 
-```python
-spark.sql('SELECT * FROM default.events WHERE eventTime >= "2020-10-01 00:00:00" <= "2020-10-01 12:00:00"')
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    spark.sql('SELECT * FROM default.events WHERE eventTime >= "2020-10-01 00:00:00" <= "2020-10-01 12:00:00"')
+    ```
+  
+  </TabItem>
+</Tabs>
 
 Delta Lake automatically generates a partition filter so that the preceding query only reads the data in partition `date=2020-10-01` even if a partition filter is not specified.
 
 As another example, given the following table:
 
-```python
-DeltaTable.create(spark) \
-  .tableName("default.events") \
-  .addColumn("eventId", "BIGINT") \
-  .addColumn("data", "STRING") \
-  .addColumn("eventType", "STRING") \
-  .addColumn("eventTime", "TIMESTAMP") \
-  .addColumn("year", "INT", generatedAlwaysAs="YEAR(eventTime)") \
-  .addColumn("month", "INT", generatedAlwaysAs="MONTH(eventTime)") \
-  .addColumn("day", "INT", generatedAlwaysAs="DAY(eventTime)") \
-  .partitionedBy("eventType", "year", "month", "day") \
-  .execute()
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    DeltaTable.create(spark) \
+      .tableName("default.events") \
+      .addColumn("eventId", "BIGINT") \
+      .addColumn("data", "STRING") \
+      .addColumn("eventType", "STRING") \
+      .addColumn("eventTime", "TIMESTAMP") \
+      .addColumn("year", "INT", generatedAlwaysAs="YEAR(eventTime)") \
+      .addColumn("month", "INT", generatedAlwaysAs="MONTH(eventTime)") \
+      .addColumn("day", "INT", generatedAlwaysAs="DAY(eventTime)") \
+      .partitionedBy("eventType", "year", "month", "day") \
+      .execute()
+    ```
+  
+  </TabItem>
+</Tabs>
 
 If you then run the following query:
 
-```python
-spark.sql('SELECT * FROM default.events WHERE eventTime >= "2020-10-01 00:00:00" <= "2020-10-01 12:00:00"')
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    spark.sql('SELECT * FROM default.events WHERE eventTime >= "2020-10-01 00:00:00" <= "2020-10-01 12:00:00"')
+    ```
+  
+  </TabItem>
+</Tabs>
 
 Delta Lake automatically generates a partition filter so that the preceding query only reads the data in partition `year=2020/month=10/day=01` even if a partition filter is not specified.
 
@@ -460,10 +549,7 @@ Delta Lake identity columns are supported in Delta Lake 3.3 and above. They are 
   </TabItem>
 </Tabs>
 
-<Aside
-  type="caution"
-  title="Important"
->
+<Aside type="note">
   SQL APIs for identity columns are not supported yet.
 </Aside>
 
@@ -582,7 +668,7 @@ The following limitations exist when working with identity columns:
 
 ### Specify default values for columns
 
-Delta enables the specification of [default expressions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#default-columns) for columns in Delta tables. When users write to these tables without explicitly providing values for certain columns, or when they explicitly use the DEFAULT SQL keyword for a column, Delta automatically generates default values for those columns. For more information, please refer to the dedicated documentation page.
+Delta enables the specification of [default expressions](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#default-columns) for columns in Delta tables. When users write to these tables without explicitly providing values for certain columns, or when they explicitly use the `DEFAULT` SQL keyword for a column, Delta automatically generates default values for those columns. For more information, please refer to the dedicated documentation page.
 
 ### Use special characters in column names
 
@@ -598,8 +684,8 @@ Delta Lake configurations set in the SparkSession override the default [table pr
 
 For example, to set the `delta.appendOnly = true` property for all new Delta Lake tables created in a session, set the following:
 
-```python
-spark.conf.set("spark.databricks.delta.properties.defaults.appendOnly", "true")
+```sql
+SET spark.databricks.delta.properties.defaults.appendOnly = true
 ```
 
 ## Read a table
@@ -610,27 +696,27 @@ You can load a Delta table as a DataFrame by specifying a table name or a path:
   <TabItem label="SQL" active>
 
     ```sql
-    SELECT * FROM default.people10m   -- query table in the metastore
+    SELECT * FROM default.people10m -- query table in the metastore
 
-    SELECT * FROM delta.`/tmp/delta/people10m`  -- query table by path
+    SELECT * FROM delta.`/tmp/delta/people10m` -- query table by path
     ```
 
   </TabItem>
   <TabItem label="Python">
 
     ```python
-    spark.table("default.people10m")    # query table in the metastore
+    spark.table("default.people10m") # query table in the metastore
 
-    spark.read.format("delta").load("/tmp/delta/people10m")  # query table by path
+    spark.read.format("delta").load("/tmp/delta/people10m") # query table by path
     ```
 
   </TabItem>
   <TabItem label="Scala">
 
     ```scala
-    spark.table("default.people10m")      // query table in the metastore
+    spark.table("default.people10m") // query table in the metastore
 
-    spark.read.format("delta").load("/tmp/delta/people10m")  // create table by path
+    spark.read.format("delta").load("/tmp/delta/people10m") // create table by path
 
     import io.delta.implicits._
     spark.read.delta("/tmp/delta/people10m")
@@ -646,11 +732,8 @@ The DataFrame returned automatically reads the most recent snapshot of the table
 Delta Lake time travel allows you to query an older snapshot of a Delta table. Time travel has many use cases, including:
 
 - Re-creating analyses, reports, or outputs (for example, the output of a machine learning model). This could be useful for debugging or auditing, especially in regulated industries.
-
 - Writing complex temporal queries.
-
 - Fixing mistakes in your data.
-
 - Providing snapshot isolation for a set of queries for fast changing tables.
 
 This section describes the supported methods for querying older versions of tables, data retention concerns, and provides examples.
@@ -668,10 +751,16 @@ This section shows how to query an older version of a Delta table.
 
 #### SQL `AS OF` syntax
 
-```sql
-SELECT * FROM table_name TIMESTAMP AS OF timestamp_expression
-SELECT * FROM table_name VERSION AS OF version
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    SELECT * FROM table_name TIMESTAMP AS OF timestamp_expression
+    SELECT * FROM table_name VERSION AS OF version
+    ```
+  
+  </TabItem>
+</Tabs>
 
 - `timestamp_expression` can be any one of:
 
@@ -686,21 +775,33 @@ SELECT * FROM table_name VERSION AS OF version
 
 Neither `timestamp_expression` nor `version` can be subqueries.
 
-### Example
+##### Example
 
-```sql
-SELECT * FROM default.people10m TIMESTAMP AS OF '2018-10-18T22:15:12.013Z'
-SELECT * FROM delta.`/tmp/delta/people10m` VERSION AS OF 123
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    SELECT * FROM default.people10m TIMESTAMP AS OF '2018-10-18T22:15:12.013Z'
+    SELECT * FROM delta.`/tmp/delta/people10m` VERSION AS OF 123
+    ```
+  
+  </TabItem>
+</Tabs>
 
 #### DataFrameReader options
 
 DataFrameReader options allow you to create a DataFrame from a Delta table that is fixed to a specific version of the table.
 
-```python
-df1 = spark.read.format("delta").option("timestampAsOf", timestamp_string).load("/tmp/delta/people10m")
-df2 = spark.read.format("delta").option("versionAsOf", version).load("/tmp/delta/people10m")
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+    ```python
+    df1 = spark.read.format("delta").option("timestampAsOf", timestamp_string).load("/tmp/delta/people10m")
+    df2 = spark.read.format("delta").option("versionAsOf", version).load("/tmp/delta/people10m")
+    ```
+
+  </TabItem>
+</Tabs>
 
 For `timestamp_string`, only date or timestamp strings are accepted. For example, `"2019-01-01"` and `"2019-01-01T00:00:00.000Z"`.
 
@@ -708,51 +809,76 @@ A common pattern is to use the latest state of the Delta table throughout the ex
 
 Because Delta tables auto update, a DataFrame loaded from a Delta table may return different results across invocations if the underlying data is updated. By using time travel, you can fix the data returned by the DataFrame across invocations:
 
-```python
-history = spark.sql("DESCRIBE HISTORY delta.`/tmp/delta/people10m`")
-latest_version = history.selectExpr("max(version)").collect()
-df = spark.read.format("delta").option("versionAsOf", latest_version[0][0]).load("/tmp/delta/people10m")
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
 
-#### Examples
+    ```python
+    history = spark.sql("DESCRIBE HISTORY delta.`/tmp/delta/people10m`")
+    latest_version = history.selectExpr("max(version)").collect()
+    df = spark.read.format("delta").option("versionAsOf", latest_version[0][0]).load("/tmp/delta/people10m")
+    ```
+
+  </TabItem>
+</Tabs>
+
+##### Examples
 
 - Fix accidental deletes to a table for the user 111:
 
-  ```python
-  yesterday = spark.sql("SELECT CAST(date_sub(current_date(), 1) AS STRING)").collect()[0][0]
-  df = spark.read.format("delta").option("timestampAsOf", yesterday).load("/tmp/delta/events")
-  df.where("userId = 111").write.format("delta").mode("append").save("/tmp/delta/events")
-  ```
+  <Tabs syncKey="code-examples">
+    <TabItem label="Python" active>
+
+      ```python
+      yesterday = spark.sql("SELECT CAST(date_sub(current_date(), 1) AS STRING)").collect()[0][0]
+      df = spark.read.format("delta").option("timestampAsOf", yesterday).load("/tmp/delta/events")
+      df.where("userId = 111").write.format("delta").mode("append").save("/tmp/delta/events")
+      ```
+    
+    </TabItem>
+  </Tabs>
+
 
 - Fix accidental incorrect updates to a table:
 
-  ```python
-  yesterday = spark.sql("SELECT CAST(date_sub(current_date(), 1) AS STRING)").collect()[0][0]
-  df = spark.read.format("delta").option("timestampAsOf", yesterday).load("/tmp/delta/events")
-  df.createOrReplaceTempView("my_table_yesterday")
-  spark.sql('''
-  MERGE INTO delta.`/tmp/delta/events` target
-    USING my_table_yesterday source
-    ON source.userId = target.userId
-    WHEN MATCHED THEN UPDATE SET *
-  ''')
-  ```
+  <Tabs syncKey="code-examples">
+    <TabItem label="Python" active>
+
+      ```python
+      yesterday = spark.sql("SELECT CAST(date_sub(current_date(), 1) AS STRING)").collect()[0][0]
+      df = spark.read.format("delta").option("timestampAsOf", yesterday).load("/tmp/delta/events")
+      df.createOrReplaceTempView("my_table_yesterday")
+      spark.sql('''
+      MERGE INTO delta.`/tmp/delta/events` target
+        USING my_table_yesterday source
+        ON source.userId = target.userId
+        WHEN MATCHED THEN UPDATE SET *
+      ''')
+      ```
+    
+    </TabItem>
+  </Tabs>
 
 - Query the number of new customers added over the last week:
 
-  ```python
-  last_week = spark.sql("SELECT CAST(date_sub(current_date(), 7) AS STRING)").collect()[0][0]
-  df = spark.read.format("delta").option("timestampAsOf", last_week).load("/tmp/delta/events")
-  last_week_count = df.select("userId").distinct().count()
-  count = spark.read.format("delta").load("/tmp/delta/events").select("userId").distinct().count()
-  new_customers_count = count - last_week_count
-  ```
+  <Tabs syncKey="code-examples">
+    <TabItem label="Python" active>
+
+      ```python
+      last_week = spark.sql("SELECT CAST(date_sub(current_date(), 7) AS STRING)").collect()[0][0]
+      df = spark.read.format("delta").option("timestampAsOf", last_week).load("/tmp/delta/events")
+      last_week_count = df.select("userId").distinct().count()
+      count = spark.read.format("delta").load("/tmp/delta/events").select("userId").distinct().count()
+      new_customers_count = count - last_week_count
+      ```
+    
+    </TabItem>
+  </Tabs>
 
 ### Data retention
 
 To time travel to a previous version, you must retain _both_ the log and the data files for that version.
 
-The data files backing a Delta table are _never_ deleted automatically; data files are deleted only when you run [VACUUM](/delta-utility/#vacuum). `VACUUM` _does not_ delete Delta log files; log files are automatically cleaned up after checkpoints are written.
+The data files backing a Delta table are _never_ deleted automatically; data files are deleted only when you run [VACUUM](/delta-utility#remove-files-no-longer-referenced-by-a-delta-table). `VACUUM` _does not_ delete Delta log files; log files are automatically cleaned up after checkpoints are written.
 
 By default you can time travel to a Delta table up to 30 days old unless you have:
 
@@ -776,47 +902,6 @@ Each time a checkpoint is written, Delta automatically cleans up log entries old
   Increasing the table property `delta.logRetentionDuration` can help avoid
   these situations.
 </Aside>
-
-### In-Commit Timestamps
-
-#### Overview
-
-Delta Lake 3.3 introduced [In-Commit Timestamps](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#in-commit-timestamps) to provide a more reliable and consistent way to track table modification timestamps. These modification timestamps are needed for various usecases e.g. time-travel to a specific time in the past. This feature addresses limitations of the traditional approach that relied on file modification timestamps, particularly in scenarios involving data migration or replication.
-
-#### Feature Details
-
-In-Commit Timestamps stores modification timestamps within the commit itself, ensuring they remain unchanged regardless of file system operations. This provides several benefits:
-
-- **Immutable History**: Timestamps become part of the table's permanent commit history
-- **Consistent Time Travel**: Queries using timestamp-based time travel produce reliable results even after table migration
-
-Without the In-Commit Timestamp feature, Delta Lake uses file modification timestamps as the commit timestamp. This approach has various limitations:
-
-1. Data Migration Issues: When tables were moved between storage locations, file modification timestamps would change, potentially disrupting historical tracking
-2. Replication Scenarios: Timestamp inconsistencies could arise when replicating data across different environments
-3. Time Travel Reliability: These timestamp changes could affect the accuracy and consistency of time travel queries
-
-#### Enabling the Feature
-
-This is a [writer table feature](/apache-spark-connector/versioning/#-what-are-table-features) and can be enabled by setting the table property `delta.enableInCommitTimestamps` to `true`:
-
-<Tabs syncKey="code-examples">
-  <TabItem label="SQL">
-
-    ```sql
-    ALTER TABLE <table_name>
-    SET TBLPROPERTIES ('delta.enableInCommitTimestamps' = 'true');
-    ```
-
-  </TabItem>
-</Tabs>
-
-After enabling In-Commit Timestamps:
-
-- Only new write operations will include the embedded timestamps
-- File modification timestamps will continued to be used for historical commits performed before enablement
-
-See the [Versioning](/apache-spark-connector/versioning) section for more details around compatibility.
 
 ## Write to table
 
@@ -897,7 +982,14 @@ You can selectively overwrite only the data that matches an arbitrary expression
 The following command atomically replaces events in January in the target table, which is partitioned by `start_date`, with the data in `replace_data`:
 
 <Tabs syncKey="code-examples">
-  <TabItem label="Python" active>
+  <TabItem label="SQL" active>
+
+    ```sql
+    INSERT INTO TABLE events REPLACE WHERE start_data >= '2017-01-01' AND end_date <= '2017-01-31' SELECT * FROM replace_data
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
 
     ```python
     replace_data.write \
@@ -919,22 +1011,19 @@ The following command atomically replaces events in January in the target table,
     ```
 
   </TabItem>
-  <TabItem label="SQL">
-
-    ```sql
-    INSERT INTO TABLE events REPLACE WHERE start_data >= '2017-01-01' AND end_date <= '2017-01-31' SELECT * FROM replace_data
-    ```
-
-  </TabItem>
 </Tabs>
 
 This sample code writes out the data in `replace_data`, validates that it all matches the predicate, and performs an atomic replacement. If you want to write out data that doesn't all match the predicate, to replace the matching rows in the target table, you can disable the constraint check by setting `spark.databricks.delta.replaceWhere.constraintCheck.enabled` to false:
 
 <Tabs syncKey="code-examples">
-  <TabItem
-    label="Python"
-    active
-  >
+  <TabItem label="SQL" active>
+
+    ```sql
+    SET spark.databricks.delta.replaceWhere.constraintCheck.enabled=false
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
 
     ```python
     spark.conf.set("spark.databricks.delta.replaceWhere.constraintCheck.enabled", False)
@@ -945,13 +1034,6 @@ This sample code writes out the data in `replace_data`, validates that it all ma
 
     ```scala
     spark.conf.set("spark.databricks.delta.replaceWhere.constraintCheck.enabled", false)
-    ```
-
-  </TabItem>
-  <TabItem label="SQL">
-
-    ```sql
-    SET spark.databricks.delta.replaceWhere.constraintCheck.enabled=false
     ```
 
   </TabItem>
@@ -987,10 +1069,14 @@ In Delta Lake 1.0.0 and below, `replaceWhere` overwrites data matching a predica
 In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you can disable the `spark.databricks.delta.replaceWhere.dataColumns.enabled` flag:
 
 <Tabs syncKey="code-examples">
-  <TabItem
-    label="Python"
-    active
-  >
+  <TabItem label="SQL" active>
+
+    ```sql
+    SET spark.databricks.delta.replaceWhere.dataColumns.enabled=false
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
 
     ```python
     spark.conf.set("spark.databricks.delta.replaceWhere.dataColumns.enabled", False)
@@ -1000,13 +1086,6 @@ In Delta Lake 1.1.0 and above, if you want to fall back to the old behavior, you
   <TabItem label="Scala">
     ```scala
     spark.conf.set("spark.databricks.delta.replaceWhere.dataColumns.enabled", false)
-    ```
-
-  </TabItem>
-  <TabItem label="SQL">
-
-    ```sql
-    SET spark.databricks.delta.replaceWhere.dataColumns.enabled=false
     ```
 
   </TabItem>
@@ -1121,7 +1200,7 @@ The above combination of options needs to be unique for each new data that is be
 
 You can also configure idempotent writes by setting the Spark session configuration `spark.databricks.delta.write.txnAppId` and `spark.databricks.delta.write.txnVersion`. In addition, you can set `spark.databricks.delta.write.txnVersion.autoReset.enabled` to true to automatically reset `spark.databricks.delta.write.txnVersion` after every write. When both the writer options and session configuration are set, we will use the writer option values.
 
-<Aside type="caution">
+<Aside type="danger" title="Warning">
 
 This solution assumes that the data being written to Delta table(s) in multiple retries of the job is same. If a write attempt in a Delta table succeeds but due to some downstream failure there is a second write attempt with same txn options but different data, then that second write attempt will be ignored. This can cause unexpected results.
 
@@ -1130,38 +1209,35 @@ This solution assumes that the data being written to Delta table(s) in multiple 
 #### Example
 
 <Tabs syncKey="code-examples">
-  <TabItem
-    label="Python"
-    active
-  >
+  <TabItem label="SQL" active>
+
+    ```sql
+    SET spark.databricks.delta.write.txnAppId = ...;
+    SET spark.databricks.delta.write.txnVersion = ...;
+    SET spark.databricks.delta.write.txnVersion.autoReset.enabled = true; -- if set to true, this will reset txnVersion after every write
+    ```
+
+  </TabItem>
+  <TabItem label="Python">
   
-  ```python
-  app_id = ... # A unique string that is used as an application ID.
-  version = ... # A monotonically increasing number that acts as transaction version.
+    ```python
+    app_id = ... # A unique string that is used as an application ID.
+    version = ... # A monotonically increasing number that acts as transaction version.
 
-  dataFrame.write.format(...).option("txnVersion", version).option("txnAppId", app_id).save(...)
-  ```
+    dataFrame.write.format(...).option("txnVersion", version).option("txnAppId", app_id).save(...)
+    ```
 
-</TabItem>
-<TabItem label="Scala">
+  </TabItem>
+  <TabItem label="Scala">
 
-  ```scala
-  val appId = ... // A unique string that is used as an application ID.
-  version = ... // A monotonically increasing number that acts as transaction version.
+    ```scala
+    val appId = ... // A unique string that is used as an application ID.
+    version = ... // A monotonically increasing number that acts as transaction version.
 
-  dataFrame.write.format(...).option("txnVersion", version).option("txnAppId", appId).save(...)
-  ```
+    dataFrame.write.format(...).option("txnVersion", version).option("txnAppId", appId).save(...)
+    ```
 
-</TabItem>
-<TabItem label="SQL">
-
-  ```sql
-  SET spark.databricks.delta.write.txnAppId = ...;
-  SET spark.databricks.delta.write.txnVersion = ...;
-  SET spark.databricks.delta.write.txnVersion.autoReset.enabled = true; -- if set to true, this will reset txnVersion after every write
-  ```
-
-</TabItem>
+  </TabItem>
 </Tabs>
 
 ### Set user-defined commit metadata
@@ -1207,9 +1283,7 @@ You can specify user-defined strings as metadata in commits made by these operat
 Delta Lake automatically validates that the schema of the DataFrame being written is compatible with the schema of the table. Delta Lake uses the following rules to determine whether a write from a DataFrame to a table is compatible:
 
 - All DataFrame columns must exist in the target table. If there are columns in the DataFrame not present in the table, an exception is raised. Columns present in the table but not in the DataFrame are set to null.
-
 - DataFrame column data types must match the column data types in the target table. If they don't match, an exception is raised.
-
 - DataFrame column names cannot differ only by case. This means that you cannot have columns such as "Foo" and "foo" defined in the same table. While you can use Spark in case sensitive or insensitive (default) mode, Parquet is case sensitive when storing and returning column information. Delta Lake is case-preserving but insensitive when storing the schema and has this restriction to avoid potential mistakes, data corruption, or loss issues.
 
 Delta Lake support DDL to add new columns explicitly and the ability to update schema automatically.
@@ -1225,11 +1299,8 @@ Delta Lake lets you update the schema of a table. The following types of changes
 
 You can make these changes explicitly using DDL or implicitly using DML.
 
-<Aside
-type="caution"
-title="Important"
->
-When you update a Delta table schema, streams that read from that table
+<Aside type="caution" title="Important">
+  When you update a Delta table schema, streams that read from that table
 terminate. If you want the stream to continue you must restart it.
 </Aside>
 
@@ -1239,19 +1310,31 @@ You can use the following DDL to explicitly change the schema of a table.
 
 #### Add columns
 
-```sql
-ALTER TABLE table_name ADD COLUMNS (col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name], ...)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE table_name ADD COLUMNS (col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name], ...)
+    ```
+  
+  </TabItem>
+</Tabs>
 
 By default, nullability is `true`.
 
 To add a column to a nested field, use:
 
-```sql
-ALTER TABLE table_name ADD COLUMNS (col_name.nested_col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name], ...)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
 
-#### Example
+    ```sql
+    ALTER TABLE table_name ADD COLUMNS (col_name.nested_col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name], ...)
+    ```
+  
+  </TabItem>
+</Tabs>
+
+##### Example
 
 If the schema before running `ALTER TABLE boxes ADD COLUMNS (colB.nested STRING AFTER field1)` is:
 
@@ -1281,17 +1364,29 @@ the schema after is:
 
 #### Change column comment or ordering
 
-```sql
-ALTER TABLE table_name ALTER [COLUMN] col_name col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name]
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE table_name ALTER [COLUMN] col_name col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name]
+    ```
+  
+  </TabItem>
+</Tabs>
 
 To change a column in a nested field, use:
 
-```sql
-ALTER TABLE table_name ALTER [COLUMN] col_name.nested_col_name nested_col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name]
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
 
-#### Example
+    ```sql
+    ALTER TABLE table_name ALTER [COLUMN] col_name.nested_col_name nested_col_name data_type [COMMENT col_comment] [FIRST|AFTER colA_name]
+    ```
+  
+  </TabItem>
+</Tabs>
+
+##### Example
 
 If the schema before running `ALTER TABLE boxes CHANGE COLUMN colB.field2 field2 STRING FIRST` is:
 
@@ -1315,17 +1410,29 @@ the schema after is:
 
 #### Replace columns
 
-```sql
-ALTER TABLE table_name REPLACE COLUMNS (col_name1 col_type1 [COMMENT col_comment1], ...)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
 
-#### Example
+    ```sql
+    ALTER TABLE table_name REPLACE COLUMNS (col_name1 col_type1 [COMMENT col_comment1], ...)
+    ```
+  
+  </TabItem>
+</Tabs>
+
+##### Example
 
 When running the following DDL:
 
-```sql
-ALTER TABLE boxes REPLACE COLUMNS (colC STRING, colB STRUCT<field2:STRING, nested:STRING, field1:STRING>, colA STRING)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE boxes REPLACE COLUMNS (colC STRING, colB STRUCT<field2:STRING, nested:STRING, field1:STRING>, colA STRING)
+    ```
+  
+  </TabItem>
+</Tabs>
 
 if the schema before is:
 
@@ -1360,17 +1467,29 @@ To rename columns without rewriting any of the columns' existing data, you must 
 
 To rename a column:
 
-```sql
-ALTER TABLE table_name RENAME COLUMN old_col_name TO new_col_name
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE table_name RENAME COLUMN old_col_name TO new_col_name
+    ```
+
+  </TabItem>
+</Tabs>
 
 To rename a nested field:
 
-```sql
-ALTER TABLE table_name RENAME COLUMN col_name.old_nested_field TO new_nested_field
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
 
-#### Example
+    ```sql
+    ALTER TABLE table_name RENAME COLUMN col_name.old_nested_field TO new_nested_field
+    ```
+  
+  </TabItem>
+</Tabs>
+
+##### Example
 
 When you run the following command:
 
@@ -1417,43 +1536,67 @@ To drop columns as a metadata-only operation without rewriting any data files, y
 
 To drop a column:
 
-```sql
-ALTER TABLE table_name DROP COLUMN col_name
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE table_name DROP COLUMN col_name
+    ```
+  
+  </TabItem>
+</Tabs>
 
 To drop multiple columns:
 
-```sql
-ALTER TABLE table_name DROP COLUMNS (col_name_1, col_name_2)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL" active>
+
+    ```sql
+    ALTER TABLE table_name DROP COLUMNS (col_name_1, col_name_2)
+    ```
+
+  </TabItem>
+</Tabs>
 
 #### Change column type or name
 
 You can change a column's type or name or drop a column by rewriting the table. To do this, use the `overwriteSchema` option:
 
-#### Change a column type
+##### Change a column type
 
-```python
-spark.read.table(...) \
-  .withColumn("birthDate", col("birthDate").cast("date")) \
-  .write \
-  .format("delta") \
-  .mode("overwrite")
-  .option("overwriteSchema", "true") \
-  .saveAsTable(...)
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
 
-#### Change a column name
+  ```python
+  spark.read.table(...) \
+    .withColumn("birthDate", col("birthDate").cast("date")) \
+    .write \
+    .format("delta") \
+    .mode("overwrite")
+    .option("overwriteSchema", "true") \
+    .saveAsTable(...)
+  ```
 
-```python
-spark.read.table(...) \
-  .withColumnRenamed("dateOfBirth", "birthDate") \
-  .write \
-  .format("delta") \
-  .mode("overwrite") \
-  .option("overwriteSchema", "true") \
-  .saveAsTable(...)
-```
+  </TabItem>
+</Tabs>
+
+##### Change a column name
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
+
+  ```python
+  spark.read.table(...) \
+    .withColumnRenamed("dateOfBirth", "birthDate") \
+    .write \
+    .format("delta") \
+    .mode("overwrite") \
+    .option("overwriteSchema", "true") \
+    .saveAsTable(...)
+  ```
+
+  </TabItem>
+</Tabs>
 
 ### Automatic schema update
 
@@ -1476,17 +1619,14 @@ Because Parquet doesn't support `NullType`, `NullType` columns are dropped from 
 
 ## Replace table schema
 
-By default, overwriting the data in a table does not overwrite the schema. When overwriting a table using mode("`overwrite`") without replaceWhere, you may still want to overwrite the schema of the data being written. You replace the schema and partitioning of the table by setting the overwriteSchema option to true:
+By default, overwriting the data in a table does not overwrite the schema. When overwriting a table using mode `overwrite` without `replaceWhere`, you may still want to overwrite the schema of the data being written. You replace the schema and partitioning of the table by setting the `overwriteSchema` option to `true`:
 
 <Tabs syncKey="code-examples">
-  <TabItem
-    label="Python"
-    active
-  >
+  <TabItem label="Python" active>
 
-    ```python
-    df.write.option("overwriteSchema", "true")
-    ```
+  ```python
+  df.write.option("overwriteSchema", "true")
+  ```
 
   </TabItem>
 </Tabs>
@@ -1502,20 +1642,21 @@ The core challenge when you operate with views is resolving the schemas. If you 
 You can store your own metadata as a table property using `TBLPROPERTIES` in `CREATE` and `ALTER`. You can then `SHOW` that metadata. For example:
 
 <Tabs syncKey="code-examples">
-  <TabItem label="SQL">
+  <TabItem label="SQL" active>
 
-    ```sql
-    ALTER TABLE default.people10m SET TBLPROPERTIES ('department' = 'accounting', 'delta.appendOnly' = 'true');
+  ```sql
+  ALTER TABLE default.people10m SET TBLPROPERTIES ('department' = 'accounting', 'delta.appendOnly' = 'true');
 
-    -- Show the table's properties.
-    SHOW TBLPROPERTIES default.people10m;
+  -- Show the table's properties.
+  SHOW TBLPROPERTIES default.people10m;
 
-    -- Show just the 'department' table property.
-    SHOW TBLPROPERTIES default.people10m ('department');
-    ```
+  -- Show just the 'department' table property.
+  SHOW TBLPROPERTIES default.people10m ('department');
+  ```
 
   </TabItem>
 </Tabs>
+
 
 `TBLPROPERTIES` are stored as part of Delta table metadata. You cannot define new `TBLPROPERTIES` in a `CREATE` statement if a Delta table already exists in a given location.
 
@@ -1526,8 +1667,8 @@ In addition, to tailor behavior and performance, Delta Lake supports certain Del
 - Configure the number of columns for which statistics are collected: `delta.dataSkippingNumIndexedCols=n`. This property indicates to the writer that statistics are to be collected only for the first `n` columns in the table. Also the data skipping code ignores statistics for any column beyond this column index. This property takes affect only for new data that is written out.
 
 <Aside type="note">
-  - Modifying a Delta table property is a write operation that will conflict
-  with other concurrent write operations, causing them to fail. We recommend
+  Modifying a Delta table property is a write operation that will conflict
+  with other [concurrent write operations](/concurrency-control), causing them to fail. We recommend
   that you modify a table property only when there are no concurrent write
   operations on the table.
 </Aside>
@@ -1604,23 +1745,6 @@ It supports `SHOW COLUMNS` and `DESCRIBE TABLE`.
 
 It also provides the following unique commands:
 
-<Tabs syncKey="code-examples">
-  <TabItem
-    label="DESCRIBE DETAIL"
-    active
-  >
-    Provides information about schema, partitioning, table size, and so on. For
-    details, see [Retrieve Delta table
-    details](/delta-utility/#retrieve-delta-table-history).
-  </TabItem>
-  <TabItem label="DESCRIBE HISTORY">
-    Provides provenance information, including the operation, user, and so on,
-    and operation metrics for each write to a table. Table history is retained
-    for 30 days. For details, see [Retrieve Delta table
-    history](/delta-utility/#retrieve-delta-table-history).
-  </TabItem>
-</Tabs>
-
 ### `DESCRIBE DETAIL`
 
 Provides information about schema, partitioning, table size, and so on. For details, see [Retrieve Delta table details](/delta-utility/#retrieve-delta-table-history).
@@ -1682,6 +1806,14 @@ For many Delta Lake operations, you enable integration with Apache Spark DataSou
 </Tabs>
 
 Alternatively, you can add configurations when submitting your Spark application using `spark-submit` or when starting `spark-shell` or `pyspark` by specifying them as command-line parameters.
+
+```bash
+spark-submit --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"  ...
+```
+
+```bash
+pyspark --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
+```
 
 ## Configure storage credentials
 

--- a/src/content/docs/delta-batch.mdx
+++ b/src/content/docs/delta-batch.mdx
@@ -3,8 +3,7 @@ title: Table batch reads and writes
 description: Learn how to perform batch reads and writes on Delta tables.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta Lake supports most of the options provided by Apache Spark DataFrame read and write APIs for performing batch reads and writes on tables.
 

--- a/src/content/docs/delta-change-data-feed.mdx
+++ b/src/content/docs/delta-change-data-feed.mdx
@@ -3,8 +3,7 @@ title: Change data feed
 description: Learn how to get row-level change information from Delta tables using the Delta change data feed.
 ---
 
-import { Tabs, TabItem } from "@astrojs/starlight/components";
-import { Code, Aside } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Change Data Feed (CDF) feature allows Delta tables to track row-level changes between versions of a Delta table. When enabled on a Delta table, the runtime records "change events" for all the data written into the table. This includes the row data along with metadata indicating whether the specified row was inserted, deleted, or updated.
 

--- a/src/content/docs/delta-change-data-feed.mdx
+++ b/src/content/docs/delta-change-data-feed.mdx
@@ -3,7 +3,7 @@ title: Change data feed
 description: Learn how to get row-level change information from Delta tables using the Delta change data feed.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Change Data Feed (CDF) feature allows Delta tables to track row-level changes between versions of a Delta table. When enabled on a Delta table, the runtime records "change events" for all the data written into the table. This includes the row data along with metadata indicating whether the specified row was inserted, deleted, or updated.
 
@@ -23,30 +23,44 @@ You must explicitly enable the change data feed option using one of the followin
 
 - **New table**: Set the table property `delta.enableChangeDataFeed = true` in the `CREATE TABLE` command.
 
-<Code
-  code={`CREATE TABLE student (id INT, name STRING, age INT) TBLPROPERTIES (delta.enableChangeDataFeed = true)`}
-  lang="sql"
-/>
+  <Tabs syncKey="code-examples">
+    <TabItem label="SQL" active>
+
+      ```sql
+      CREATE TABLE student (id INT, name STRING, age INT) TBLPROPERTIES (delta.enableChangeDataFeed = true)
+      ```
+    
+    </TabItem>
+  </Tabs>
 
 - **Existing table**: Set the table property `delta.enableChangeDataFeed = true` in the `ALTER TABLE` command.
 
-<Code
-  code={`ALTER TABLE myDeltaTable SET TBLPROPERTIES (delta.enableChangeDataFeed = true)`}
-  lang="sql"
-/>
+  <Tabs syncKey="code-examples">
+    <TabItem label="SQL" active>
+
+      ```sql
+      ALTER TABLE myDeltaTable SET TBLPROPERTIES (delta.enableChangeDataFeed = true)
+      ```
+
+    </TabItem>
+  </Tabs>
 
 - **All new tables**:
 
-<Code
-  code={`set spark.databricks.delta.properties.defaults.enableChangeDataFeed = true;`}
-  lang="sql"
-/>
+  <Tabs syncKey="code-examples">
+    <TabItem label="SQL" active>
+
+      ```sql
+      set spark.databricks.delta.properties.defaults.enableChangeDataFeed = true;
+      ```
+    
+    </TabItem>
+  </Tabs>
 
 <Aside type="caution" title="Important">
-Once you enable the change data feed option for a table, you can no longer write to the table using Delta Lake 1.2.1 or below. You can always read the table.
+  Once you enable the change data feed option for a table, you can no longer write to the table using Delta Lake 1.2.1 or below. You can always read the table.
 
-Only changes made _after_ you enable the change data feed are recorded; past changes to a table are not captured.
-
+  Only changes made _after_ you enable the change data feed are recorded; past changes to a table are not captured.
 </Aside>
 
 ### Change data storage
@@ -65,52 +79,89 @@ If you provide a version lower or timestamp older than one that has recorded cha
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`-- version as ints or longs e.g. changes from version 0 to 10
-SELECT * FROM table_changes('tableName', 0, 10)
 
--- timestamp as string formatted timestamps SELECT \* FROM table_changes('tableName', '2021-04-21 05:45:46', '2021-05-21 12:00:00')
+    ```sql
+    -- version as ints or longs e.g. changes from version 0 to 10
+    SELECT * FROM table_changes('tableName', 0, 10)
 
--- providing only the startingVersion/timestamp SELECT \* FROM table_changes('tableName', 0)
+    -- timestamp as string formatted timestamps
+    SELECT * FROM table_changes('tableName', '2021-04-21 05:45:46', '2021-05-21 12:00:00')
 
--- database/schema names inside the string for table name, with backticks for escaping dots and special characters SELECT \* FROM table_changes('dbName.\`dotted.tableName\`', '2021-04-21 06:45:46' , '2021-05-21 12:00:00')
+    -- providing only the startingVersion/timestamp
+    SELECT * FROM table_changes('tableName', 0)
 
--- path based tables SELECT \* FROM table_changes_by_path('\\path', '2021-04-21 05:45:46')`} lang="sql" />
+    -- database/schema names inside the string for table name, with backticks for escaping dots and special characters
+    SELECT * FROM table_changes('dbName.`dotted.tableName`', '2021-04-21 06:45:46' , '2021-05-21 12:00:00')
+
+    -- path based tables
+    SELECT * FROM table_changes_by_path('\path', '2021-04-21 05:45:46')
+    ```
+
   </TabItem>
 
   <TabItem label="Python">
-    <Code code={`# version as ints or longs
-spark.read.format("delta") \\
-  .option("readChangeFeed", "true") \\
-  .option("startingVersion", 0) \\
-  .option("endingVersion", 10) \\
-  .table("myDeltaTable")
+    
+    ```python
+    # version as ints or longs
+    spark.read.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingVersion", 0) \
+      .option("endingVersion", 10) \
+      .table("myDeltaTable")
 
-# timestamps as formatted timestamp
+    # timestamps as formatted timestamp
+    spark.read.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingTimestamp", '2021-04-21 05:45:46') \
+      .option("endingTimestamp", '2021-05-21 12:00:00') \
+      .table("myDeltaTable")
 
-spark.read.format("delta") \\ .option("readChangeFeed", "true") \\ .option("startingTimestamp", '2021-04-21 05:45:46') \\ .option("endingTimestamp", '2021-05-21 12:00:00') \\ .table("myDeltaTable")
+    # providing only the startingVersion/timestamp
+    spark.read.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingVersion", 0) \
+      .table("myDeltaTable")
 
-# providing only the startingVersion/timestamp
 
-spark.read.format("delta") \\ .option("readChangeFeed", "true") \\ .option("startingVersion", 0) \\ .table("myDeltaTable")
+    # path based tables
+    spark.read.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingTimestamp", '2021-04-21 05:45:46') \
+      .load("pathToMyDeltaTable")
+    ```
 
-# path based tables
-
-spark.read.format("delta") \\ .option("readChangeFeed", "true") \\ .option("startingTimestamp", '2021-04-21 05:45:46') \\ .load("pathToMyDeltaTable")`} lang="python" />
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`// version as ints or longs
-spark.read.format("delta")
-  .option("readChangeFeed", "true")
-  .option("startingVersion", 0)
-  .option("endingVersion", 10)
-  .table("myDeltaTable")
 
-// timestamps as formatted timestamp spark.read.format("delta") .option("readChangeFeed", "true") .option("startingTimestamp", "2021-04-21 05:45:46") .option("endingTimestamp", "2021-05-21 12:00:00") .table("myDeltaTable")
+    ```scala
+    // version as ints or longs
+    spark.read.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", 0)
+      .option("endingVersion", 10)
+      .table("myDeltaTable")
 
-// providing only the startingVersion/timestamp spark.read.format("delta") .option("readChangeFeed", "true") .option("startingVersion", 0) .table("myDeltaTable")
+    // timestamps as formatted timestamp
+    spark.read.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingTimestamp", "2021-04-21 05:45:46")
+      .option("endingTimestamp", "2021-05-21 12:00:00")
+      .table("myDeltaTable")
 
-// path based tables spark.read.format("delta") .option("readChangeFeed", "true") .option("startingTimestamp", "2021-04-21 05:45:46") .load("pathToMyDeltaTable")`} lang="scala" />
+    // providing only the startingVersion/timestamp
+    spark.read.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", 0)
+      .table("myDeltaTable")
+
+    // path based tables
+    spark.read.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingTimestamp", "2021-04-21 05:45:46")
+      .load("pathToMyDeltaTable")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -118,49 +169,72 @@ spark.read.format("delta")
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`# providing a starting version
-spark.readStream.format("delta") \\
-  .option("readChangeFeed", "true") \\
-  .option("startingVersion", 0) \\
-  .table("myDeltaTable")
+  
+    ```python
+    # providing a starting version
+    spark.readStream.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingVersion", 0) \
+      .table("myDeltaTable")
 
-# providing a starting timestamp
+    # providing a starting timestamp
+    spark.readStream.format("delta") \
+      .option("readChangeFeed", "true") \
+      .option("startingTimestamp", "2021-04-21 05:35:43") \
+      .load("/pathToMyDeltaTable")
 
-spark.readStream.format("delta") \\ .option("readChangeFeed", "true") \\ .option("startingTimestamp", "2021-04-21 05:35:43") \\ .load("/pathToMyDeltaTable")
+    # not providing a starting version/timestamp will result in the latest snapshot being fetched first
+    spark.readStream.format("delta") \
+      .option("readChangeFeed", "true") \
+      .table("myDeltaTable")
+    ```
 
-# not providing a starting version/timestamp will result in the latest snapshot being fetched first
-
-spark.readStream.format("delta") \\ .option("readChangeFeed", "true") \\ .table("myDeltaTable")`} lang="python" />
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`// providing a starting version
-spark.readStream.format("delta")
-  .option("readChangeFeed", "true")
-  .option("startingVersion", 0)
-  .table("myDeltaTable")
+  
+    ```scala
+    // providing a starting version
+    spark.readStream.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", 0)
+      .table("myDeltaTable")
 
-// providing a starting timestamp spark.readStream.format("delta") .option("readChangeFeed", "true") .option("startingVersion", "2021-04-21 05:35:43") .load("/pathToMyDeltaTable")
+    // providing a starting timestamp
+    spark.readStream.format("delta")
+      .option("readChangeFeed", "true")
+      .option("startingVersion", "2021-04-21 05:35:43")
+      .load("/pathToMyDeltaTable")
 
-// not providing a starting version/timestamp will result in the latest snapshot being fetched first spark.readStream.format("delta") .option("readChangeFeed", "true") .table("myDeltaTable")`} lang="scala" />
+    // not providing a starting version/timestamp will result in the latest snapshot being fetched first
+    spark.readStream.format("delta")
+      .option("readChangeFeed", "true")
+      .table("myDeltaTable")
+    ```
+  
   </TabItem>
 </Tabs>
 
 To get the change data while reading the table, set the option `readChangeFeed` to `true`. The `startingVersion` or `startingTimestamp` are optional and if not provided the stream returns the latest snapshot of the table at the time of streaming as an `INSERT` and future changes as change data. Options like rate limits (`maxFilesPerTrigger`, `maxBytesPerTrigger`) and `excludeRegex` are also supported when reading change data.
 
 <Aside type="note">
-Rate limiting can be atomic for versions other than the starting snapshot version. That is, the entire commit version will be rate limited or the entire commit will be returned.
+  Rate limiting can be atomic for versions other than the starting snapshot version. That is, the entire commit version will be rate limited or the entire commit will be returned.
 
-By default if a user passes in a version or timestamp exceeding the last commit on a table, the error `timestampGreaterThanLatestCommit` will be thrown. CDF can handle the out of range version case, if the user sets the following configuration to `true`.
+  By default if a user passes in a version or timestamp exceeding the last commit on a table, the error `timestampGreaterThanLatestCommit` will be thrown. CDF can handle the out of range version case, if the user sets the following configuration to `true`.
 
-```sql
-set spark.databricks.delta.changeDataFeed.timestampOutOfRange.enabled = true;
-```
+  <Tabs syncKey="code-examples">
+    <TabItem label="Python">
 
-If you provide a start version greater than the last commit on a table or a start timestamp newer than the last commit on a table, then when the preceding configuration is enabled, an empty read result is returned.
+      ```sql
+      set spark.databricks.delta.changeDataFeed.timestampOutOfRange.enabled = true;
+      ```
+    
+    </TabItem>
+  </Tabs>
 
-If you provide an end version greater than the last commit on a table or an end timestamp newer than the last commit on a table, then when the preceding configuration is enabled in batch read mode, all changes between the start version and the last commit are be returned.
+  If you provide a start version greater than the last commit on a table or a start timestamp newer than the last commit on a table, then when the preceding configuration is enabled, an empty read result is returned.
 
+  If you provide an end version greater than the last commit on a table or an end timestamp newer than the last commit on a table, then when the preceding configuration is enabled in batch read mode, all changes between the start version and the last commit are be returned.
 </Aside>
 
 ## What is the schema for the change data feed?
@@ -190,16 +264,15 @@ the value after the update.
 With column mapping enabled on a Delta table, you can drop or rename columns in the table without rewriting data files for existing data. With column mapping enabled, change data feed has limitations after performing non-additive schema changes such as renaming or dropping a column, changing data type, or nullability changes.
 
 <Aside type="caution" title="Important">
-In Delta Lake 2.0 and before, tables with column mapping enabled do not support streaming reads or batch reads on change data feed.
+  In Delta Lake 2.0 and before, tables with column mapping enabled do not support streaming reads or batch reads on change data feed.
 
-In Delta Lake 2.1, tables with column mapping enabled support batch reads on change data feed as long as there are no non-additive schema changes. Streaming reads of change data feed of tables with column mapping enabled is not supported.
+  In Delta Lake 2.1, tables with column mapping enabled support batch reads on change data feed as long as there are no non-additive schema changes. Streaming reads of change data feed of tables with column mapping enabled is not supported.
 
-In Delta Lake 2.2, tables with column mapping enabled support both batch and streaming reads on change data feed as long as there are no non-additive schema changes.
+  In Delta Lake 2.2, tables with column mapping enabled support both batch and streaming reads on change data feed as long as there are no non-additive schema changes.
 
-In Delta Lake 2.3 and above, you can perform batch reads on change data feed for tables with column mapping enabled that have experienced non-additive schema changes. Instead of using the schema of the latest version of the table, read operations use the schema of the end version of the table specified in the query. Queries still fail if the version range specified spans a non-additive schema change.
+  In Delta Lake 2.3 and above, you can perform batch reads on change data feed for tables with column mapping enabled that have experienced non-additive schema changes. Instead of using the schema of the latest version of the table, read operations use the schema of the end version of the table specified in the query. Queries still fail if the version range specified spans a non-additive schema change.
 
-In Delta Lake 3.0 and above, you can perform streaming read on change data feed for tables with column mapping enabled that have experienced non-additive schema changes by enabling [schema tracking](/delta-streaming/#tracking-non-additive-schema-changes).
-
+  In Delta Lake 3.0 and above, you can perform streaming read on change data feed for tables with column mapping enabled that have experienced non-additive schema changes by enabling [schema tracking](/delta-streaming/#tracking-non-additive-schema-changes).
 </Aside>
 
 ## Frequently asked questions (FAQ)

--- a/src/content/docs/delta-constraints.mdx
+++ b/src/content/docs/delta-constraints.mdx
@@ -3,8 +3,7 @@ title: Constraints
 description: Learn how Delta tables apply constraints.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta tables support standard SQL constraint management clauses that ensure that the quality and integrity of data added to a table is automatically verified. When a constraint is violated, Delta Lake throws an `InvariantViolationException` to signal that the new data can't be added.
 

--- a/src/content/docs/delta-constraints.mdx
+++ b/src/content/docs/delta-constraints.mdx
@@ -3,7 +3,7 @@ title: Constraints
 description: Learn how Delta tables apply constraints.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta tables support standard SQL constraint management clauses that ensure that the quality and integrity of data added to a table is automatically verified. When a constraint is violated, Delta Lake throws an `InvariantViolationException` to signal that the new data can't be added.
 
@@ -28,6 +28,7 @@ You specify `NOT NULL` constraints in the schema when you create a table and dro
 
 <Tabs>
   <TabItem label="SQL">
+
     ```sql
     CREATE TABLE default.people10m (
         id INT NOT NULL,
@@ -54,6 +55,7 @@ You manage `CHECK` constraints using the `ALTER TABLE ADD CONSTRAINT` and `ALTER
 
 <Tabs>
   <TabItem label="SQL">
+
     ```sql
     CREATE TABLE default.people10m (
        id INT,
@@ -77,6 +79,7 @@ You manage `CHECK` constraints using the `ALTER TABLE ADD CONSTRAINT` and `ALTER
 
 <Tabs>
   <TabItem label="SQL">
+
     ```sql
     ALTER TABLE default.people10m ADD CONSTRAINT validIds CHECK (id > 1 and id < 99999999);
 

--- a/src/content/docs/delta-drop-feature.mdx
+++ b/src/content/docs/delta-drop-feature.mdx
@@ -28,6 +28,7 @@ You can drop the following Delta table features:
 
 - `deletionVectors`. See [What are deletion vectors?](/delta-deletion-vectors/).
 - `typeWidening-preview`. See [Delta type widening](/delta-type-widening/). Type widening is available in preview in Delta Lake 3.2.0 and above.
+- `typeWidening`. See [Delta type widening](/delta-type-widening/). Type widening is available in preview in Delta Lake 4.0.0 and above.
 - `v2Checkpoint`. See [V2 Checkpoint Spec](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#v2-spec). Drop support for V2 Checkpoints is available in Delta Lake 3.1.0 and above.
 - `columnMapping`. See [Delta column mapping](/delta-column-mapping/). Drop support for column mapping is available in Delta Lake 3.3.0 and above.
 - `vacuumProtocolCheck`. See [Vacuum Protocol Check Spec](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#vacuum-protocol-check). Drop support for vacuum protocol check is available in Delta Lake 3.3.0 and above.

--- a/src/content/docs/delta-spark-connect.mdx
+++ b/src/content/docs/delta-spark-connect.mdx
@@ -1,0 +1,95 @@
+---
+title: Delta Connect (aka Spark Connect Support in Delta)
+description: Learn about Delta Connect - Spark Connect Support in Delta.
+---
+
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside } from "@astrojs/starlight/components";
+
+<Aside type="note">
+  This feature is available in Delta Lake 4.0.0 and above. Please note, Delta Connect is currently in preview and not recommended for production workloads.
+</Aside>
+
+Delta Connect adds [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) support to Delta Lake for Apache Spark. Spark Connect is a new initiative that adds a decoupled client-server infrastructure which allows remote connectivity from Spark from everywhere. Delta Connect allows all Delta Lake operations to work in your application running as a client connected to the Spark server.
+
+## Motivation
+
+Delta Connect is expected to br0ng the same benefits as Spark Connect:
+
+1. Upgrading to more recent versions of Spark and Delta Lake is now easier because the client interface is being completely decoupled from the server.
+2. Simpler integration of Spark and Delta Lake with developer tooling. IDEs no longer have to integrate with the full Spark and Delta Lake implementation, and instead can integrate with a thin-client.
+3. Support for languages other than Java/Scala and Python. Clients "merely" have to generate Protocol Buffers and therefore become simpler to implement.
+4. Spark and Delta Lake will become more stable, as user code is no longer running in the same JVM as Spark's driver.
+5. Remote connectivity. Code can run anywhere now, as there is a gRPC layer between the user interface and the driver.
+
+## How to start the Spark Server with Delta
+
+1. Download `spark-4.0.0-bin-hadoop3.tgz` from [Spark 4.0.0](https://archive.apache.org/dist/spark/spark-4.0.0).
+2. Start the Spark Connect server with the Delta Lake Connect plugins:
+
+    ```bash
+    sbin/start-connect-server.sh \ 
+      --packages io.delta:delta-connect-server_2.13:4.0.0,com.google.protobuf:protobuf-java:3.25.1 \ 
+      --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" \
+      --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog" \
+      --conf "spark.connect.extensions.relation.classes=org.apache.spark.sql.connect.delta.DeltaRelationPlugin" \
+      --conf "spark.connect.extensions.command.classes=org.apache.spark.sql.connect.delta.DeltaCommandPlugin"
+    ```
+
+## How to use the Python Spark Connect Client with Delta
+
+The Delta Lake Connect Python client is included in the same PyPi package as Delta Lake Spark.
+
+1. `pip install pyspark==4.0.0`.
+2. `pip install delta-spark==4.0.0`.
+3. The usage is the same as Spark Connect (e.g. `./bin/pyspark --remote "sc://localhost"`). We just need to pass in a remote `SparkSession` (instead of a local one) to the `DeltaTable` API.
+
+An example:
+
+<Tabs syncKey="code-examples">
+  <TabItem label="Python">
+
+    ```python
+    from delta.tables import DeltaTable
+    from pyspark.sql import SparkSession
+    from pyspark.sql.functions import *
+
+    deltaTable = DeltaTable.forName(spark, "my_table")
+    deltaTable.toDF().show()
+
+    deltaTable.update(
+      condition = "id % 2 == 0",
+      set = {"id": "id + 100"}
+    )
+    ```
+  
+  </TabItem>
+</Tabs>
+
+## How to use the Scala Spark Connect Client with Delta
+
+Make sure you are using Java 17!
+
+```bash
+./bin/spark-shell --remote "sc://localhost" --packages io.delta:delta-connect-client_2.13:4.0.0,com.google.protobuf:protobuf-java:3.25.1
+```
+
+An example:
+    
+<Tabs syncKey="code-examples">
+  <TabItem label="Scala">
+
+    ```scala
+    import io.delta.tables.DeltaTable
+
+    val deltaTable = DeltaTable.forName(spark, "my_table")
+    deltaTable.toDF.show()
+
+    deltaTable.updateExpr(
+      condition = "id % 2 == 0",
+      set = Map("id" -> "id + 100")
+    )
+    ```
+  
+  </TabItem>
+</Tabs>

--- a/src/content/docs/delta-spark-connect.mdx
+++ b/src/content/docs/delta-spark-connect.mdx
@@ -3,8 +3,7 @@ title: Delta Connect (aka Spark Connect Support in Delta)
 description: Learn about Delta Connect - Spark Connect Support in Delta.
 ---
 
-import { Tabs, TabItem } from "@astrojs/starlight/components";
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Aside type="note">
   This feature is available in Delta Lake 4.0.0 and above. Please note, Delta Connect is currently in preview and not recommended for production workloads.

--- a/src/content/docs/delta-storage.mdx
+++ b/src/content/docs/delta-storage.mdx
@@ -64,16 +64,18 @@ In this default mode, Delta Lake supports concurrent reads from multiple cluster
 
 This section explains how to quickly start reading and writing Delta tables on S3 using single-cluster mode. For a detailed explanation of the configuration, see [Setup Configuration (S3 multi-cluster)](#setup-configuration-s3-multi-cluster).
 
-1. Use the following command to launch a Spark shell with Delta Lake and S3 support (assuming you use Spark 3.5.3 which is pre-built for Hadoop 3.3.4):
+1. Use the following command to launch a Spark shell with Delta Lake and S3 support (assuming you use Spark 4.0.0 which is pre-built for Hadoop 3.4.0):
 
 <Tabs>
   <TabItem label="Bash">
+
     ```bash
     bin/spark-shell \
-     --packages io.delta:delta-spark_2.12:3.3.0,org.apache.hadoop:hadoop-aws:3.3.4 \
+     --packages io.delta:delta-spark_2.13:4.0.0,org.apache.hadoop:hadoop-aws:3.4.0 \
      --conf spark.hadoop.fs.s3a.access.key=<your-s3-access-key> \
      --conf spark.hadoop.fs.s3a.secret.key=<your-s3-secret-key>
     ```
+
   </TabItem>
 </Tabs>
 
@@ -100,7 +102,7 @@ For efficient listing of Delta Lake metadata files on S3, set the configuration 
   <TabItem label="Scala">
     ```scala
     bin/spark-shell \
-      --packages io.delta:delta-spark_2.12:3.3.0,org.apache.hadoop:hadoop-aws:3.3.4 \
+      --packages io.delta:delta-spark_2.13:4.0.0,org.apache.hadoop:hadoop-aws:3.4.0 \
       --conf spark.hadoop.fs.s3a.access.key=<your-s3-access-key> \
       --conf spark.hadoop.fs.s3a.secret.key=<your-s3-secret-key> \
       --conf "spark.hadoop.delta.enableFastS3AListFrom=true
@@ -130,13 +132,13 @@ This mode supports concurrent writes to S3 from multiple clusters and has to be 
 
 This section explains how to quickly start reading and writing Delta tables on S3 using multi-cluster mode.
 
-1. Use the following command to launch a Spark shell with Delta Lake and S3 support (assuming you use Spark 3.5.3 which is pre-built for Hadoop 3.3.4):
+1. Use the following command to launch a Spark shell with Delta Lake and S3 support (assuming you use Spark 4.0.0 which is pre-built for Hadoop 3.4.0):
 
 <Tabs>
   <TabItem label="Bash">
     ```bash
     bin/spark-shell \
-     --packages io.delta:delta-spark_2.12:3,org.apache.hadoop:hadoop-aws:3.3.4,io.delta:delta-storage-s3-dynamodb:3.3.0 \
+     --packages io.delta:delta-spark_2.13:3,org.apache.hadoop:hadoop-aws:3.4.0,io.delta:delta-storage-s3-dynamodb:4.0.0 \
      --conf spark.hadoop.fs.s3a.access.key=<your-s3-access-key> \
      --conf spark.hadoop.fs.s3a.secret.key=<your-s3-secret-key> \
      --conf spark.delta.logStore.s3a.impl=io.delta.storage.S3DynamoDBLogStore \

--- a/src/content/docs/delta-streaming/index.mdx
+++ b/src/content/docs/delta-streaming/index.mdx
@@ -3,9 +3,7 @@ title: Table streaming reads and writes
 description: Learn how to use Delta tables as streaming sources and sinks.
 ---
 
-import { Tabs, TabItem } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { Image } from "astro:assets";
 
 Delta Lake is deeply integrated with [Spark Structured Streaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) through `readStream` and `writeStream`. Delta Lake overcomes many of the limitations typically associated with streaming systems and files, including:

--- a/src/content/docs/delta-streaming/index.mdx
+++ b/src/content/docs/delta-streaming/index.mdx
@@ -3,8 +3,7 @@ title: Table streaming reads and writes
 description: Learn how to use Delta tables as streaming sources and sinks.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
-import { Image } from "astro:assets";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta Lake is deeply integrated with [Spark Structured Streaming](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html) through `readStream` and `writeStream`. Delta Lake overcomes many of the limitations typically associated with streaming systems and files, including:
 
@@ -19,20 +18,16 @@ For many Delta Lake operations on tables, you enable integration with Apache Spa
 When you load a Delta table as a stream source and use it in a streaming query, the query processes all of the data present in the table as well as any new data that arrives after the stream is started.
 
 <Tabs syncKey="code-examples">
-  <TabItem label="Python">
-    <Code code={`spark.readStream.format("delta") \\
-  .load("/tmp/delta/events")
-
-from delta.tables import \* spark.readStream.delta("/tmp/delta/events")`} lang="python" />
-
-  </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`spark.readStream.format("delta")
-  .load("/tmp/delta/events")
+    
+    ```scala
+    spark.readStream.format("delta")
+      .load("/tmp/delta/events")
 
-import io.delta.implicits._
-spark.readStream.delta("/tmp/delta/events")`} lang="scala" />
+    import io.delta.implicits._
+    spark.readStream.delta("/tmp/delta/events")
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -70,12 +65,13 @@ When you delete at partition boundaries (that is, the `WHERE` is on a partition 
 
 <Tabs>
   <TabItem label="Scala">
-    <Code
-      code={`spark.readStream.format("delta")
-  .option("ignoreDeletes", "true")
-  .load("/tmp/delta/user_events")`}
-      lang="scala"
-    />
+  
+    ```scala
+    spark.readStream.format("delta")
+      .option("ignoreDeletes", "true")
+      .load("/tmp/delta/user_events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -83,12 +79,13 @@ However, if you have to delete data based on `user_email`, then you will need to
 
 <Tabs>
   <TabItem label="Scala">
-    <Code
-      code={`spark.readStream.format("delta")
-  .option("ignoreChanges", "true")
-  .load("/tmp/delta/user_events")`}
-      lang="scala"
-    />
+  
+    ```scala
+    spark.readStream.format("delta")
+      .option("ignoreChanges", "true")
+      .load("/tmp/delta/user_events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -121,12 +118,13 @@ For example, suppose you have a table `user_events`. If you want to read changes
 
 <Tabs>
   <TabItem label="Scala">
-    <Code
-      code={`spark.readStream.format("delta")
-  .option("startingVersion", "5")
-  .load("/tmp/delta/user_events")`}
-      lang="scala"
-    />
+  
+    ```scala
+    spark.readStream.format("delta")
+      .option("startingVersion", "5")
+      .load("/tmp/delta/user_events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -134,12 +132,13 @@ If you want to read changes since 2018-10-18, use:
 
 <Tabs>
   <TabItem label="Scala">
-    <Code
-      code={`spark.readStream.format("delta")
-  .option("startingTimestamp", "2018-10-18")
-  .load("/tmp/delta/user_events")`}
-      lang="scala"
-    />
+  
+    ```scala
+    spark.readStream.format("delta")
+      .option("startingTimestamp", "2018-10-18")
+      .load("/tmp/delta/user_events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -176,22 +175,23 @@ Suppose you have a table `user_events` with an `event_time` column. Your streami
 
 <Tabs>
   <TabItem label="Scala">
-    <Code
-      code={`spark.readStream.format("delta")
-  .option("withEventTimeOrder", "true")
-  .load("/tmp/delta/user_events")
-  .withWatermark("event_time", "10 seconds")`}
-      lang="scala"
-    />
+  
+    ```scala
+    spark.readStream.format("delta")
+      .option("withEventTimeOrder", "true")
+      .load("/tmp/delta/user_events")
+      .withWatermark("event_time", "10 seconds")
+    ```
+
   </TabItem>
 </Tabs>
 
 <Aside type="note">
-You can also enable this with Spark config on the cluster which will apply to all streaming queries:
+  You can also enable this with Spark config on the cluster which will apply to all streaming queries:
 
-```
-spark.databricks.delta.withEventTimeOrder.enabled true
-```
+  ```
+  spark.databricks.delta.withEventTimeOrder.enabled true
+  ```
 
 </Aside>
 
@@ -213,12 +213,20 @@ The option `schemaTrackingLocation` is used to specify the path for schema track
 
 <Tabs>
 	<TabItem label="Python">
-		<Code code={`checkpoint_path = "/path/to/checkpointLocation"
 
-(spark.readStream .option("schemaTrackingLocation", checkpoint_path) .table("delta_source_table") .writeStream .option("checkpointLocation", checkpoint_path) .toTable("output_table") )`} lang="python" />
+    ```python
+    checkpoint_path = "/path/to/checkpointLocation"
 
-</TabItem>
-
+    (spark.readStream
+      .option("schemaTrackingLocation", checkpoint_path)
+      .table("delta_source_table")
+      .writeStream
+      .option("checkpointLocation", checkpoint_path)
+      .toTable("output_table")
+    )
+    ```
+  
+  </TabItem>
 </Tabs>
 
 ## Delta table as a sink
@@ -226,7 +234,7 @@ The option `schemaTrackingLocation` is used to specify the path for schema track
 You can also write data into a Delta table using Structured Streaming. The transaction log enables Delta Lake to guarantee exactly-once processing, even when there are other streams or batch queries running concurrently against the table.
 
 <Aside type="note">
-The Delta Lake `VACUUM` function removes all files not managed by Delta Lake but skips any directories that begin with `_`. You can safely store checkpoints alongside other data and metadata for a Delta table using a directory structure such as `<table_name>/_checkpoints`.
+  The Delta Lake `VACUUM` function removes all files not managed by Delta Lake but skips any directories that begin with `_`. You can safely store checkpoints alongside other data and metadata for a Delta table using a directory structure such as `<table_name>/_checkpoints`.
 </Aside>
 
 ### Append mode
@@ -237,25 +245,33 @@ You can use the path method:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`events.writeStream
-  .format("delta")
-  .outputMode("append")
-  .option("checkpointLocation", "/tmp/delta/_checkpoints/")
-  .start("/delta/events")`} lang="python" />
+  
+    ```python
+    events.writeStream
+      .format("delta")
+      .outputMode("append")
+      .option("checkpointLocation", "/tmp/delta/_checkpoints/")
+      .start("/delta/events")
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`events.writeStream
-  .format("delta")
-  .outputMode("append")
-  .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
-  .start("/tmp/delta/events")
+  
+    ```scala
+    events.writeStream
+      .format("delta")
+      .outputMode("append")
+      .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
+      .start("/tmp/delta/events")
 
-import io.delta.implicits._
-events.writeStream
-  .outputMode("append")
-  .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
-  .delta("/tmp/delta/events")`} lang="scala" />
+    import io.delta.implicits._
+    events.writeStream
+      .outputMode("append")
+      .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
+      .delta("/tmp/delta/events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -263,18 +279,26 @@ or the `toTable` method (in Spark 3.1 and higher) as follows:
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`events.writeStream
-  .format("delta")
-  .outputMode("append")
-  .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
-  .toTable("events")`} lang="python" />
+  
+    ```python
+    events.writeStream
+      .format("delta")
+      .outputMode("append")
+      .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
+      .toTable("events")
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`events.writeStream
-  .outputMode("append")
-  .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
-  .toTable("events")`} lang="scala" />
+  
+    ```scala
+    events.writeStream
+      .outputMode("append")
+      .option("checkpointLocation", "/tmp/delta/events/_checkpoints/")
+      .toTable("events")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -284,30 +308,38 @@ You can also use Structured Streaming to replace the entire table with every bat
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`(spark.readStream
-  .format("delta")
-  .load("/tmp/delta/events")
-  .groupBy("customerId")
-  .count()
-  .writeStream
-  .format("delta")
-  .outputMode("complete")
-  .option("checkpointLocation", "/tmp/delta/eventsByCustomer/_checkpoints/")
-  .start("/tmp/delta/eventsByCustomer")
-)`} lang="python" />
+  
+    ```python
+    (spark.readStream
+      .format("delta")
+      .load("/tmp/delta/events")
+      .groupBy("customerId")
+      .count()
+      .writeStream
+      .format("delta")
+      .outputMode("complete")
+      .option("checkpointLocation", "/tmp/delta/eventsByCustomer/_checkpoints/")
+      .start("/tmp/delta/eventsByCustomer")
+    )
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`spark.readStream
-  .format("delta")
-  .load("/tmp/delta/events")
-  .groupBy("customerId")
-  .count()
-  .writeStream
-  .format("delta")
-  .outputMode("complete")
-  .option("checkpointLocation", "/tmp/delta/eventsByCustomer/_checkpoints/")
-  .start("/tmp/delta/eventsByCustomer")`} lang="scala" />
+  
+    ```scala
+    spark.readStream
+      .format("delta")
+      .load("/tmp/delta/events")
+      .groupBy("customerId")
+      .count()
+      .writeStream
+      .format("delta")
+      .outputMode("complete")
+      .option("checkpointLocation", "/tmp/delta/eventsByCustomer/_checkpoints/")
+      .start("/tmp/delta/eventsByCustomer")
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -343,17 +375,26 @@ The same `DataFrameWriter` options can be used to achieve the idempotent writes 
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`app_id = ... # A unique string that is used as an application ID.
+  
+    ```python
+    app_id = ... # A unique string that is used as an application ID.
 
-def writeToDeltaLakeTableIdempotent(batch_df, batch_id): batch_df.write.format(...).option("txnVersion", batch_id).option("txnAppId", app_id).save(...) # location 1 batch_df.write.format(...).option("txnVersion", batch_id).option("txnAppId", app_id).save(...) # location 2`} lang="python" />
-
+    def writeToDeltaLakeTableIdempotent(batch_df, batch_id):
+      batch_df.write.format(...).option("txnVersion", batch_id).option("txnAppId", app_id).save(...) # location 1
+      batch_df.write.format(...).option("txnVersion", batch_id).option("txnAppId", app_id).save(...) # location 2
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`val appId = ... // A unique string that is used as an application ID.
-streamingDF.writeStream.foreachBatch { (batchDF: DataFrame, batchId: Long) =>
-  batchDF.write.format(...).option("txnVersion", batchId).option("txnAppId", appId).save(...)  // location 1
-  batchDF.write.format(...).option("txnVersion", batchId).option("txnAppId", appId).save(...)  // location 2
-}`} lang="scala" />
+  
+    ```scala
+    val appId = ... // A unique string that is used as an application ID.
+    streamingDF.writeStream.foreachBatch { (batchDF: DataFrame, batchId: Long) =>
+      batchDF.write.format(...).option("txnVersion", batchId).option("txnAppId", appId).save(...)  // location 1
+      batchDF.write.format(...).option("txnVersion", batchId).option("txnAppId", appId).save(...)  // location 2
+    }
+    ```
+  
   </TabItem>
 </Tabs>

--- a/src/content/docs/delta-type-widening.mdx
+++ b/src/content/docs/delta-type-widening.mdx
@@ -6,17 +6,35 @@ description: Learn about type widening in Delta.
 import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
 <Aside type="note">
-  This feature is available in preview in Delta Lake 3.2 and above.
+  This feature is available in preview in Delta Lake 3.2 and above, and fully supported in Delta Lake 4.0 and above.
 </Aside>
 
-The type widening feature allows changing the type of columns in a Delta table to a wider type. This enables manual type changes using the `ALTER TABLE ALTER COLUMN` command and automatic type migration with schema evolution in `INSERT` and `MERGE INTO` commands.
+The type widening feature allows changing the type of columns in a Delta table to a wider type. This enables manual type changes using the `ALTER TABLE ALTER COLUMN` command and automatic type migration with schema evolution during write operations.
 
 ## Supported type changes
 
-The feature preview in Delta Lake 3.2 and above supports a limited set of type changes:
+The feature introduces a limited set of supported type changes in Delta Lake 3.2 and expands it in Delta Lake 4.0 and above.
 
-- `BYTE` to `SHORT` and `INT`
-- `SHORT` to `INT`
+| Source type | Supported wider types - Delta 3.2 | Supported wider types - Delta 4.0           |
+|-------------|-----------------------------------|---------------------------------------------|
+| `byte`      | `short`, `int`                    | `short`, `int`, `long`, `decimal`, `double` |
+| `short`     | `int`                             | `int`, `long`, `decimal`, `double`          |
+| `int`       |                                   | `long`, `decimal`, `double`                 |
+| `long`      |                                   | `decimal`                                   |
+| `float`     |                                   | `double`                                    |
+| `decimal`   |                                   | `decimal` with greater precision and scale  |
+| `date`      |                                   | `timestampNTZ`                              |
+
+To avoid accidentally promoting integer values to decimals, you must **manually commit** type changes from `byte`, `short`, `int`, or `long` to `decimal` or `double`. When promoting an integer type to `decimal` or `double`, if any downstream ingestion writes this value back to an integer column, Spark will truncate the fractional part of the values by default.
+
+<Aside type="note">
+  When changing an integer or decimal type to decimal, the total precision must be equal to or greater than the starting precision. If you also increase the scale, the total precision must increase by a corresponding amount.
+  That is, `decimal(p, s)` can be changed to `decimal(p + k1, s + k2)` iff `k1 >= k2 >= 0`.
+
+  For example, if you want to add two decimal places to a field with `decimal(10,1)`, the minimum target is `decimal(12,3)`.
+
+  The minimum target for `byte`, `short`, and `int` types is `decimal(10,0)`. The minimum target for `long` is `decimal(20,0)`.
+</Aside>
 
 Type changes are supported for top-level columns as well as fields nested inside structs, maps and arrays.
 
@@ -26,10 +44,9 @@ Type changes are supported for top-level columns as well as fields nested inside
   type="note"
   title="Important"
 >
-  Enabling type widening sets the Delta table feature `typeWidening-preview`, a
-  reader/writer protocol feature. Only clients that support this table feature
-  can read and write to the table once the table feature is set. You must use
-  Delta Lake 3.2 or above to read and write to such Delta tables.
+  Enabling type widening using Delta Lake 3.3 and above sets the Delta table feature `typeWidening`, a reader/writer protocol feature. Only clients that support this table feature can read and write to the table once the table feature is set. You must use Delta Lake 3.3 or above to read and write to such Delta tables.
+  
+  Enabling type widening using Delta Lake 3.2 sets the Delta table feature `typeWidening-preview` on the table instead. You must use Delta Lake 3.2 or above to read and write to such Delta tables.
 </Aside>
 
 You can enable type widening on an existing table by setting the `delta.enableTypeWidening` table property to `true`:
@@ -82,14 +99,21 @@ The table schema is updated without rewriting the underlying Parquet files.
 
 ## Type changes with automatic schema evolution
 
-Type changes are applied automatically during ingestion with `INSERT` and `MERGE INTO` commands when:
+Schema evolution works with type widening to update data types in target tables to match the type of incoming data.
 
-- Type widening is enabled on the target table
-- The command runs with [automatic schema evolution](/delta-update/#automatic-schema-evolution) enabled
-- The source column type is wider than the target column type
-- Changing the target column type to the source type is a [supported type change](#supported-type-changes)
+<Aside type="note">
+  Without type widening enabled, schema evolution always attempts to downcast data to match column types in the target table. If you don't want to automatically widen data types in your target tables, disable type widening before you run workloads with schema evolution enabled.
+</Aside>
 
-When all conditions are satisfied, the target table schema is updated automatically to change the target column type to the source column type.
+To use schema evolution to widen the data type of a column during ingestion, you must meet the following conditions:
+
+- The write command runs with automatic schema evolution enabled.
+- The target table has type widening enabled.
+- The source column type is wider than the target column type.
+- Type widening supports the type change.
+- The type change is not one of `byte`, `short`, `int`, or `long` to `decimal` or `double`. These type changes can only be applied manually using ALTER TABLE to avoid accidental promotion of integers to decimals.
+
+Type mismatches that don't meet all of these conditions follow normal schema enforcement rules.
 
 ## Removing the type widening table feature
 
@@ -97,12 +121,33 @@ The type widening feature can be removed from a Delta table using the `DROP FEAT
 
 <Tabs>
   <TabItem label="SQL">
+
     ```sql
-    ALTER TABLE <table_name> DROP FEATURE 'typeWidening-preview' [TRUNCATE HISTORY]
+    ALTER TABLE <table_name> DROP FEATURE 'typeWidening' [TRUNCATE HISTORY]
     ```
+
   </TabItem>
 </Tabs>
+
+<Aside type="note">
+  Tables that enabled type widening using Delta Lake 3.2 require dropping feature `typeWidening-preview` instead.
+</Aside>
 
 See [Drop Delta table features](/delta-drop-feature/) for more information on dropping Delta table features.
 
 When dropping the type widening feature, the underlying Parquet files are rewritten when necessary to ensure that the column types in the files match the column types in the Delta table schema. After the type widening feature is removed from the table, Delta clients that don't support the feature can read and write to the table.
+
+## Limitations
+
+### Iceberg Compatibility
+
+Iceberg doesn't support all type changes covered by type widening, see [Iceberg Schema Evolution](https://iceberg.apache.org/spec/#schema-evolution). In particular, Iceberg V2 does not support the following type changes:
+
+- `byte`, `short`, `int`, `long` to `decimal` or `double`
+- decimal scale increase
+- `date` to `timestampNTZ`
+
+When [UniForm with Iceberg compatibility](/delta-uniform) is enabled on a Delta table, applying one of these type changes results in an error.
+
+If you apply one of these unsupported type changes to a Delta table, enabling [Uniform with Iceberg compatibility](/delta-uniform) on the table results in an error.
+To resolve the error, you must [drop the type widening table feature](#removing-the-type-widening-table-feature).

--- a/src/content/docs/delta-update.mdx
+++ b/src/content/docs/delta-update.mdx
@@ -3,8 +3,7 @@ title: Table deletes, updates, and merges
 description: Learn how to delete data from and update data in Delta tables.
 ---
 
-import { Tabs, TabItem } from "@astrojs/starlight/components";
-import { Code, Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta Lake supports several statements to facilitate deleting data from and updating data in Delta tables.
 
@@ -14,52 +13,70 @@ You can remove data that matches a predicate from a Delta table. For instance, i
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`DELETE FROM people10m WHERE birthDate < '1955-01-01'
 
-DELETE FROM delta.\`/tmp/delta/people-10m\` WHERE birthDate < '1955-01-01'`} lang="sql" />
+    ```sql
+    DELETE FROM people10m WHERE birthDate < '1955-01-01'
+
+    DELETE FROM delta.`/tmp/delta/people-10m` WHERE birthDate < '1955-01-01'
+    ```
 
   </TabItem>
+</Tabs>
 
+See [Configure SparkSession](/delta-batch#configure-sparksession) for the steps to enable support for SQL commands.
+
+<Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
-from pyspark.sql.functions import *
+  
+    ```python
+    from delta.tables import *
+    from pyspark.sql.functions import *
 
-deltaTable = DeltaTable.forPath(spark, '/tmp/delta/people-10m')
+    deltaTable = DeltaTable.forPath(spark, '/tmp/delta/people-10m')
 
-# Declare the predicate by using a SQL-formatted string.
+    # Declare the predicate by using a SQL-formatted string.
+    deltaTable.delete("birthDate < '1955-01-01'")
 
-deltaTable.delete("birthDate < '1955-01-01'")
-
-# Declare the predicate by using Spark SQL functions.
-
-deltaTable.delete(col('birthDate') < '1960-01-01')`} lang="python" />
-
+    # Declare the predicate by using Spark SQL functions.
+    deltaTable.delete(col('birthDate') < '1960-01-01')
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
+    val deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
 
-// Declare the predicate by using a SQL-formatted string. deltaTable.delete("birthDate < '1955-01-01'")
+    // Declare the predicate by using a SQL-formatted string.
+    deltaTable.delete("birthDate < '1955-01-01'")
 
-import org.apache.spark.sql.functions._
-import spark.implicits._
+    import org.apache.spark.sql.functions._
+    import spark.implicits._
 
-// Declare the predicate by using Spark SQL functions and implicits. deltaTable.delete(col("birthDate") < "1955-01-01")`} lang="scala" />
-
+    // Declare the predicate by using Spark SQL functions and implicits.
+    deltaTable.delete(col("birthDate") < "1955-01-01")
+    ```
+  
   </TabItem>
 
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
-import org.apache.spark.sql.functions;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m");
+    ```java
+    import io.delta.tables.*;
+    import org.apache.spark.sql.functions;
 
-// Declare the predicate by using a SQL-formatted string. deltaTable.delete("birthDate < '1955-01-01'");
+    DeltaTable deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m");
 
-// Declare the predicate by using Spark SQL functions. deltaTable.delete(functions.col("birthDate").lt(functions.lit("1955-01-01")));`} lang="java" />
+    // Declare the predicate by using a SQL-formatted string.
+    deltaTable.delete("birthDate < '1955-01-01'");
 
+    // Declare the predicate by using Spark SQL functions.
+    deltaTable.delete(functions.col("birthDate").lt(functions.lit("1955-01-01")));
+    ``` 
+  
   </TabItem>
 </Tabs>
 
@@ -87,62 +104,93 @@ You can update data that matches a predicate in a Delta table. For example, in a
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`UPDATE people10m SET gender = 'Female' WHERE gender = 'F';
-UPDATE people10m SET gender = 'Male' WHERE gender = 'M';
+  
+    ```sql
+    UPDATE people10m SET gender = 'Female' WHERE gender = 'F';
+    UPDATE people10m SET gender = 'Male' WHERE gender = 'M';
 
-UPDATE delta.\`/tmp/delta/people-10m\` SET gender = 'Female' WHERE gender = 'F'; UPDATE delta.\`/tmp/delta/people-10m\` SET gender = 'Male' WHERE gender = 'M';`} lang="sql" />
-
+    UPDATE delta.`/tmp/delta/people-10m` SET gender = 'Female' WHERE gender = 'F';
+    UPDATE delta.`/tmp/delta/people-10m` SET gender = 'Male' WHERE gender = 'M';
+    ```
+  
   </TabItem>
 </Tabs>
 
-See [Configure SparkSession](/delta-batch/#configure-sparksession) for the steps to enable support for SQL commands.
+See [Configure SparkSession](/delta-batch#configure-sparksession) for the steps to enable support for SQL commands.
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
-from pyspark.sql.functions import *
 
-deltaTable = DeltaTable.forPath(spark, '/tmp/delta/people-10m')
+    ```python
+    from delta.tables import *
+    from pyspark.sql.functions import *
 
-# Declare the predicate by using a SQL-formatted string.
+    deltaTable = DeltaTable.forPath(spark, '/tmp/delta/people-10m')
 
-deltaTable.update( condition = "gender = 'F'", set = { "gender": "'Female'" } )
+    # Declare the predicate by using a SQL-formatted string.
+    deltaTable.update(
+      condition = "gender = 'F'",
+      set = { "gender": "'Female'" }
+    )
 
-# Declare the predicate by using Spark SQL functions.
-
-deltaTable.update( condition = col('gender') == 'M', set = { 'gender': lit('Male') } )`} lang="python" />
-
+    # Declare the predicate by using Spark SQL functions.
+    deltaTable.update(
+      condition = col('gender') == 'M',
+      set = { 'gender': lit('Male') }
+    )
+    ```
+  
   </TabItem>
 
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
+    val deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
 
-// Declare the predicate by using a SQL-formatted string. deltaTable.updateExpr( "gender = 'F'", Map("gender" -> "'Female'")
+    // Declare the predicate by using a SQL-formatted string.
+    deltaTable.updateExpr(
+      "gender = 'F'",
+      Map("gender" -> "'Female'")
 
-import org.apache.spark.sql.functions._
-import spark.implicits._
+    import org.apache.spark.sql.functions._
+    import spark.implicits._
 
-// Declare the predicate by using Spark SQL functions and implicits. deltaTable.update( col("gender") === "M", Map("gender" -> lit("Male")));`} lang="scala" />
-
+    // Declare the predicate by using Spark SQL functions and implicits.
+    deltaTable.update(
+      col("gender") === "M",
+      Map("gender" -> lit("Male")));
+    ```
+  
   </TabItem>
 
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
-import org.apache.spark.sql.functions;
-import java.util.HashMap;
+  
+    ```java
+    import io.delta.tables.*;
+    import org.apache.spark.sql.functions;
+    import java.util.HashMap;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, "/data/events/");
+    DeltaTable deltaTable = DeltaTable.forPath(spark, "/data/events/");
 
-// Declare the predicate by using a SQL-formatted string. deltaTable.updateExpr( "gender = 'F'", new HashMap<String, String>() {{
-    put("gender", "'Female'");
-  }} );
+    // Declare the predicate by using a SQL-formatted string.
+    deltaTable.updateExpr(
+      "gender = 'F'",
+      new HashMap<String, String>() {{
+        put("gender", "'Female'");
+      }}
+    );
 
-// Declare the predicate by using Spark SQL functions. deltaTable.update( functions.col(gender).eq("M"), new HashMap<String, Column>() {{
-    put("gender", functions.lit("Male"));
-  }} );`} lang="java" />
-
+    // Declare the predicate by using Spark SQL functions.
+    deltaTable.update(
+      functions.col(gender).eq("M"),
+      new HashMap<String, Column>() {{
+        put("gender", functions.lit("Male"));
+      }}
+    );
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -161,43 +209,44 @@ Suppose you have a source table named `people10mupdates` or a source path at `/t
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code
-      code={`MERGE INTO people10m
-USING people10mupdates
-ON people10m.id = people10mupdates.id
-WHEN MATCHED THEN
-  UPDATE SET
-    id = people10mupdates.id,
-    firstName = people10mupdates.firstName,
-    middleName = people10mupdates.middleName,
-    lastName = people10mupdates.lastName,
-    gender = people10mupdates.gender,
-    birthDate = people10mupdates.birthDate,
-    ssn = people10mupdates.ssn,
-    salary = people10mupdates.salary
-WHEN NOT MATCHED
-  THEN INSERT (
-    id,
-    firstName,
-    middleName,
-    lastName,
-    gender,
-    birthDate,
-    ssn,
-    salary
-  )
-  VALUES (
-    people10mupdates.id,
-    people10mupdates.firstName,
-    people10mupdates.middleName,
-    people10mupdates.lastName,
-    people10mupdates.gender,
-    people10mupdates.birthDate,
-    people10mupdates.ssn,
-    people10mupdates.salary
-  )`}
-      lang="sql"
-    />
+  
+    ```sql
+    MERGE INTO people10m
+    USING people10mupdates
+    ON people10m.id = people10mupdates.id
+    WHEN MATCHED THEN
+      UPDATE SET
+        id = people10mupdates.id,
+        firstName = people10mupdates.firstName,
+        middleName = people10mupdates.middleName,
+        lastName = people10mupdates.lastName,
+        gender = people10mupdates.gender,
+        birthDate = people10mupdates.birthDate,
+        ssn = people10mupdates.ssn,
+        salary = people10mupdates.salary
+    WHEN NOT MATCHED
+      THEN INSERT (
+        id,
+        firstName,
+        middleName,
+        lastName,
+        gender,
+        birthDate,
+        ssn,
+        salary
+      )
+      VALUES (
+        people10mupdates.id,
+        people10mupdates.firstName,
+        people10mupdates.middleName,
+        people10mupdates.lastName,
+        people10mupdates.gender,
+        people10mupdates.birthDate,
+        people10mupdates.ssn,
+        people10mupdates.salary
+      )
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -205,53 +254,133 @@ See [Configure SparkSession](/delta-batch/#configure-sparksession) for the steps
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
 
-deltaTablePeople = DeltaTable.forPath(spark, '/tmp/delta/people-10m') deltaTablePeopleUpdates = DeltaTable.forPath(spark, '/tmp/delta/people-10m-updates')
+    ```python
+    from delta.tables import *
 
-dfUpdates = deltaTablePeopleUpdates.toDF()
+    deltaTablePeople = DeltaTable.forPath(spark, '/tmp/delta/people-10m')
+    deltaTablePeopleUpdates = DeltaTable.forPath(spark, '/tmp/delta/people-10m-updates')
 
-deltaTablePeople.alias('people') \\ .merge( dfUpdates.alias('updates'), 'people.id = updates.id' ) \\ .whenMatchedUpdate(set = { "id": "updates.id", "firstName": "updates.firstName", "middleName": "updates.middleName", "lastName": "updates.lastName", "gender": "updates.gender", "birthDate": "updates.birthDate", "ssn": "updates.ssn", "salary": "updates.salary" } ) \\ .whenNotMatchedInsert(values = { "id": "updates.id", "firstName": "updates.firstName", "middleName": "updates.middleName", "lastName": "updates.lastName", "gender": "updates.gender", "birthDate": "updates.birthDate", "ssn": "updates.ssn", "salary": "updates.salary" } ) \\ .execute()`} lang="python" />
+    dfUpdates = deltaTablePeopleUpdates.toDF()
 
+    deltaTablePeople.alias('people') \
+      .merge(
+        dfUpdates.alias('updates'),
+        'people.id = updates.id'
+      ) \
+      .whenMatchedUpdate(set =
+        {
+          "id": "updates.id",
+          "firstName": "updates.firstName",
+          "middleName": "updates.middleName",
+          "lastName": "updates.lastName",
+          "gender": "updates.gender",
+          "birthDate": "updates.birthDate",
+          "ssn": "updates.ssn",
+          "salary": "updates.salary"
+        }
+      ) \
+      .whenNotMatchedInsert(values =
+        {
+          "id": "updates.id",
+          "firstName": "updates.firstName",
+          "middleName": "updates.middleName",
+          "lastName": "updates.lastName",
+          "gender": "updates.gender",
+          "birthDate": "updates.birthDate",
+          "ssn": "updates.ssn",
+          "salary": "updates.salary"
+        }
+      ) \
+      .execute()
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
-import org.apache.spark.sql.functions._
+  
+    ```scala
+    import io.delta.tables._
+    import org.apache.spark.sql.functions._
 
-val deltaTablePeople = DeltaTable.forPath(spark, "/tmp/delta/people-10m") val deltaTablePeopleUpdates = DeltaTable.forPath(spark, "tmp/delta/people-10m-updates") val dfUpdates = deltaTablePeopleUpdates.toDF()
+    val deltaTablePeople = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
+    val deltaTablePeopleUpdates = DeltaTable.forPath(spark, "tmp/delta/people-10m-updates")
+    val dfUpdates = deltaTablePeopleUpdates.toDF()
 
-deltaTablePeople .as("people") .merge( dfUpdates.as("updates"), "people.id = updates.id") .whenMatched .updateExpr( Map( "id" -> "updates.id", "firstName" -> "updates.firstName", "middleName" -> "updates.middleName", "lastName" -> "updates.lastName", "gender" -> "updates.gender", "birthDate" -> "updates.birthDate", "ssn" -> "updates.ssn", "salary" -> "updates.salary" )) .whenNotMatched .insertExpr( Map( "id" -> "updates.id", "firstName" -> "updates.firstName", "middleName" -> "updates.middleName", "lastName" -> "updates.lastName", "gender" -> "updates.gender", "birthDate" -> "updates.birthDate", "ssn" -> "updates.ssn", "salary" -> "updates.salary" )) .execute()`} lang="scala" />
-
+    deltaTablePeople
+      .as("people")
+      .merge(
+        dfUpdates.as("updates"),
+        "people.id = updates.id")
+      .whenMatched
+      .updateExpr(
+        Map(
+          "id" -> "updates.id",
+          "firstName" -> "updates.firstName",
+          "middleName" -> "updates.middleName",
+          "lastName" -> "updates.lastName",
+          "gender" -> "updates.gender",
+          "birthDate" -> "updates.birthDate",
+          "ssn" -> "updates.ssn",
+          "salary" -> "updates.salary"
+        ))
+      .whenNotMatched
+      .insertExpr(
+        Map(
+          "id" -> "updates.id",
+          "firstName" -> "updates.firstName",
+          "middleName" -> "updates.middleName",
+          "lastName" -> "updates.lastName",
+          "gender" -> "updates.gender",
+          "birthDate" -> "updates.birthDate",
+          "ssn" -> "updates.ssn",
+          "salary" -> "updates.salary"
+        ))
+      .execute()
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
-import org.apache.spark.sql.functions;
-import java.util.HashMap;
+  
+    ```java
+    import io.delta.tables.*;
+    import org.apache.spark.sql.functions;
+    import java.util.HashMap;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m") Dataset<Row> dfUpdates = spark.read("delta").load("/tmp/delta/people-10m-updates")
+    DeltaTable deltaTable = DeltaTable.forPath(spark, "/tmp/delta/people-10m")
+    Dataset<Row> dfUpdates = spark.read("delta").load("/tmp/delta/people-10m-updates")
 
-deltaTable .as("people") .merge( dfUpdates.as("updates"), "people.id = updates.id") .whenMatched() .updateExpr( new HashMap<String, String>() {{
-      put("id", "updates.id");
-      put("firstName", "updates.firstName");
-      put("middleName", "updates.middleName");
-      put("lastName", "updates.lastName");
-      put("gender", "updates.gender");
-      put("birthDate", "updates.birthDate");
-      put("ssn", "updates.ssn");
-      put("salary", "updates.salary");
-    }}) .whenNotMatched() .insertExpr( new HashMap<String, String>() {{
-      put("id", "updates.id");
-      put("firstName", "updates.firstName");
-      put("middleName", "updates.middleName");
-      put("lastName", "updates.lastName");
-      put("gender", "updates.gender");
-      put("birthDate", "updates.birthDate");
-      put("ssn", "updates.ssn");
-      put("salary", "updates.salary");
-    }}) .execute();`} lang="java" />
-
+    deltaTable
+      .as("people")
+      .merge(
+        dfUpdates.as("updates"),
+        "people.id = updates.id")
+      .whenMatched()
+      .updateExpr(
+        new HashMap<String, String>() {{
+          put("id", "updates.id");
+          put("firstName", "updates.firstName");
+          put("middleName", "updates.middleName");
+          put("lastName", "updates.lastName");
+          put("gender", "updates.gender");
+          put("birthDate", "updates.birthDate");
+          put("ssn", "updates.ssn");
+          put("salary", "updates.salary");
+        }})
+      .whenNotMatched()
+      .insertExpr(
+        new HashMap<String, String>() {{
+          put("id", "updates.id");
+          put("firstName", "updates.firstName");
+          put("middleName", "updates.middleName");
+          put("lastName", "updates.lastName");
+          put("gender", "updates.gender");
+          put("birthDate", "updates.birthDate");
+          put("ssn", "updates.ssn");
+          put("salary", "updates.salary");
+        }})
+      .execute();
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -289,92 +418,113 @@ You can use the `WHEN NOT MATCHED BY SOURCE` clause to `UPDATE` or `DELETE` reco
 The following code example shows the basic syntax of using this for deletes, overwriting the target table with the contents of the source table and deleting unmatched records in the target table.
 
 <Tabs syncKey="code-examples">
-  <TabItem label="Python">
-    <Code code={`(targetDF
-  .merge(sourceDF, "source.key = target.key")
-  .whenMatchedUpdateAll()
-  .whenNotMatchedInsertAll()
-  .whenNotMatchedBySourceDelete()
-  .execute())`} lang="python" />
-  </TabItem>
-
-<TabItem label="Scala">
-  <Code
-    code={`targetDF
-  .merge(sourceDF, "source.key = target.key")
-  .whenMatched()
-  .updateAll()
-  .whenNotMatched()
-  .insertAll()
-  .whenNotMatchedBySource()
-  .delete()
-  .execute()`}
-    lang="scala"
-  />
-</TabItem>
-
   <TabItem label="SQL">
-    <Code code={`MERGE INTO target
-USING source
-ON source.key = target.key
-WHEN MATCHED
-  UPDATE SET *
-WHEN NOT MATCHED
-  INSERT *
-WHEN NOT MATCHED BY SOURCE
-  DELETE`} lang="sql" />
+  
+    ```sql
+    MERGE INTO target
+    USING source
+    ON source.key = target.key
+    WHEN MATCHED
+      UPDATE SET *
+    WHEN NOT MATCHED
+      INSERT *
+    WHEN NOT MATCHED BY SOURCE
+      DELETE
+    ```
+  
+  </TabItem>
+  <TabItem label="Python">
+
+    ```python
+    (targetDF
+      .merge(sourceDF, "source.key = target.key")
+      .whenMatchedUpdateAll()
+      .whenNotMatchedInsertAll()
+      .whenNotMatchedBySourceDelete()
+      .execute()
+    )
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    targetDF
+      .merge(sourceDF, "source.key = target.key")
+      .whenMatched()
+      .updateAll()
+      .whenNotMatched()
+      .insertAll()
+      .whenNotMatchedBySource()
+      .delete()
+      .execute()
+    ```
+  
   </TabItem>
 </Tabs>
 
 The following example adds conditions to the `WHEN NOT MATCHED BY SOURCE` clause and specifies values to update in unmatched target rows.
 
 <Tabs syncKey="code-examples">
-	<TabItem label="Python">
-		<Code code={`(targetDF
-(targetDF
-	.merge(sourceDF, "source.key = target.key")
-	.whenMatchedUpdate(
-		set = {"target.lastSeen": "source.timestamp"}
-	)
-	.whenNotMatchedInsert(
-		values = {
-			"target.key": "source.key",
-			"target.lastSeen": "source.timestamp", 
-			"target.status": "'active'"
-		}
-	)
-	.whenNotMatchedBySourceUpdate(
-		condition="target.lastSeen >= (current_date() - INTERVAL '5' DAY)",
-		set = {"target.status": "'inactive'"}
-	)
-	.execute()
-)`} lang="python" />
-	</TabItem>
+  <TabItem label="SQL">
+  
+    ```sql
+    MERGE INTO target
+    USING source
+    ON source.key = target.key
+    WHEN MATCHED THEN
+      UPDATE SET target.lastSeen = source.timestamp
+    WHEN NOT MATCHED THEN
+      INSERT (key, lastSeen, status) VALUES (source.key,  source.timestamp, 'active')
+    WHEN NOT MATCHED BY SOURCE AND target.lastSeen >= (current_date() - INTERVAL '5' DAY) THEN
+      UPDATE SET target.status = 'inactive'
+    ```
+  
+  </TabItem>
+  <TabItem label="Python">
 
-    <TabItem label="Scala">
-    	<Code code={`targetDF
-    .merge(sourceDF, "source.key = target.key")
-    .whenMatched()
-    .updateExpr(Map("target.lastSeen" -> "source.timestamp"))
-    .whenNotMatched()
-    .insertExpr(Map(
-    	"target.key" -> "source.key",
-    	"target.lastSeen" -> "source.timestamp",
-    	"target.status" -> "'active'",
-    	)
+    ```python  
+    (targetDF
+      .merge(sourceDF, "source.key = target.key")
+      .whenMatchedUpdate(
+        set = {"target.lastSeen": "source.timestamp"}
+      )
+      .whenNotMatchedInsert(
+        values = {
+          "target.key": "source.key",
+          "target.lastSeen": "source.timestamp",
+          "target.status": "'active'"
+        }
+      )
+      .whenNotMatchedBySourceUpdate(
+        condition="target.lastSeen >= (current_date() - INTERVAL '5' DAY)",
+        set = {"target.status": "'inactive'"}
+      )
+      .execute()
     )
-    .whenNotMatchedBySource("target.lastSeen >= (current_date() - INTERVAL '5' DAY)")
-    .updateExpr(Map("target.status" -> "'inactive'"))
-    .execute()`} lang="scala" />
-    </TabItem>
-
-    <TabItem label="SQL">
-    	<Code code={`MERGE INTO target
-
-USING source ON source.key = target.key WHEN MATCHED THEN UPDATE SET target.lastSeen = source.timestamp WHEN NOT MATCHED THEN INSERT (key, lastSeen, status) VALUES (source.key, source.timestamp, 'active') WHEN NOT MATCHED BY SOURCE AND target.lastSeen >= (current_date() - INTERVAL '5' DAY) THEN UPDATE SET target.status = 'inactive'`} lang="sql" />
-
-</TabItem>
-
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    targetDF
+      .merge(sourceDF, "source.key = target.key")
+      .whenMatched()
+      .updateExpr(Map("target.lastSeen" -> "source.timestamp"))
+      .whenNotMatched()
+      .insertExpr(Map(
+        "target.key" -> "source.key",
+        "target.lastSeen" -> "source.timestamp",
+        "target.status" -> "'active'",
+        )
+      )
+      .whenNotMatchedBySource("target.lastSeen >= (current_date() - INTERVAL '5' DAY)")
+      .updateExpr(Map("target.status" -> "'inactive'"))
+      .execute()
+    ```
+  
+  </TabItem>
 </Tabs>
 
 ### Operation semantics
@@ -390,13 +540,22 @@ Here is a detailed description of the `merge` programmatic operation.
   - If there are multiple `whenMatched` clauses, then they are evaluated in the order they are specified. All `whenMatched` clauses, except the last one, must have conditions.
   - If none of the `whenMatched` conditions evaluate to true for a source and target row pair that matches the merge condition, then the target row is left unchanged.
   - To update all the columns of the target Delta table with the corresponding columns of the source dataset, use `whenMatched(...).updateAll()`. This is equivalent to:
-    ```scala
-    whenMatched(...).updateExpr(Map("col1" -> "source.col1", "col2" -> "source.col2", ...))
-    ```
+
+    <Tabs syncKey="code-examples">
+      <TabItem label="Scala">
+
+        ```scala
+        whenMatched(...).updateExpr(Map("col1" -> "source.col1", "col2" -> "source.col2", ...))
+        ```
+      
+      </TabItem>
+    </Tabs>
+
     for all the columns of the target Delta table. Therefore, this action assumes that the source table has the same columns as those in the target table, otherwise the query throws an analysis error.
-    > **Note**
-    >
-    > This behavior changes when automatic schema migration is enabled. See [Automatic schema evolution](/delta-update/#automatic-schema-evolution) for details.
+
+    <Aside type="note">
+      This behavior changes when automatic schema migration is enabled. See [Automatic schema evolution](/delta-update/#automatic-schema-evolution) for details.
+    </Aside>
 
 - `whenNotMatched` clauses are executed when a source row does not match any target row based on the match condition. These clauses have the following semantics.
 
@@ -404,13 +563,22 @@ Here is a detailed description of the `merge` programmatic operation.
   - Each `whenNotMatched` clause can have an optional condition. If the clause condition is present, a source row is inserted only if that condition is true for that row. Otherwise, the source column is ignored.
   - If there are multiple `whenNotMatched` clauses, then they are evaluated in the order they are specified. All `whenNotMatched` clauses, except the last one, must have conditions.
   - To insert all the columns of the target Delta table with the corresponding columns of the source dataset, use `whenNotMatched(...).insertAll()`. This is equivalent to:
-    ```scala
-    whenNotMatched(...).insertExpr(Map("col1" -> "source.col1", "col2" -> "source.col2", ...))
-    ```
+    
+    <Tabs syncKey="code-examples">
+      <TabItem label="Scala">
+
+        ```scala
+        whenNotMatched(...).insertExpr(Map("col1" -> "source.col1", "col2" -> "source.col2", ...))
+        ```
+      
+      </TabItem>
+    </Tabs>
+
     for all the columns of the target Delta table. Therefore, this action assumes that the source table has the same columns as those in the target table, otherwise the query throws an analysis error.
-    > **Note**
-    >
-    > This behavior changes when automatic schema migration is enabled. See [Automatic schema evolution](/delta-update/#automatic-schema-evolution) for details.
+
+    <Aside type="note">
+      This behavior changes when automatic schema migration is enabled. See [Automatic schema evolution](/delta-update/#automatic-schema-evolution) for details.
+    </Aside>
 
 - `whenNotMatchedBySource` clauses are executed when a target row does not match any source row based on the merge condition. These clauses have the following semantics.
   - `whenNotMatchedBySource` clauses can specify `delete` and `update` actions.
@@ -418,7 +586,7 @@ Here is a detailed description of the `merge` programmatic operation.
   - If there are multiple `whenNotMatchedBySource` clauses, then they are evaluated in the order they are specified. All `whenNotMatchedBySource` clauses, except the last one, must have conditions.
   - By definition, `whenNotMatchedBySource` clauses do not have a source row to pull column values from, and so source columns can't be referenced. For each column to be modified, you can either specify a literal or perform an action on the target column, such as `SET target.deleted_count = target.deleted_count + 1`.
 
-<aside class="caution">
+<Aside type="caution" title="Important!">
   - A `merge` operation can fail if multiple rows of the source dataset match
   and the merge attempts to update the same rows of the target Delta table.
   According to the SQL semantics of merge, such an update operation is ambiguous
@@ -428,9 +596,10 @@ Here is a detailed description of the `merge` programmatic operation.
   example](/delta-update/#write-change-data-into-a-delta-table)—it shows how to
   preprocess the change dataset (that is, the source dataset) to retain only the
   latest change for each key before applying that change into the target Delta
-  table. - You can apply a SQL `MERGE` operation on a SQL VIEW only if the view
+  table.
+  - You can apply a SQL `MERGE` operation on a SQL VIEW only if the view
   has been defined as `CREATE VIEW viewName AS SELECT * FROM deltaTable`.
-</aside>
+</Aside>
 
 ### Schema validation
 
@@ -450,17 +619,17 @@ Schema evolution allows users to resolve schema mismatches between the target an
 1. A column in the source table is not present in the target table. The new column is added to the target schema, and its values are inserted or updated using the source values.
 2. A column in the target table is not present in the source table. The target schema is left unchanged; the values in the additional target column are either left unchanged (for `UPDATE`) or set to `NULL` (for `INSERT`).
 
-<aside class="caution">
+<Aside type="caution">
   To use schema evolution, you must set the Spark session
   configuration`spark.databricks.delta.schema.autoMerge.enabled` to `true`
   before you run the `merge` command.
-</aside>
+</Aside>
 
-<aside class="note">
+<Aside type="note">
   In Delta 2.3 and above, columns present in the source table can be specified
   by name in insert or update actions. In Delta 2.2 and below, only `INSERT *`
   or `UPDATE SET *` actions can be used for schema evolution with merge.
-</aside>
+</Aside>
 
 Here are a few examples of the effects of `merge` operation with and without schema evolution.
 
@@ -475,9 +644,9 @@ Here are a few examples of the effects of `merge` operation with and without sch
 
 Delta `MERGE INTO` supports resolving struct fields by name and evolving schemas for arrays of structs. With schema evolution enabled, target table schemas will evolve for arrays of structs, which also works with any nested structs inside of arrays.
 
-> **Note**
->
-> In Delta 2.3 and above, struct fields present in the source table can be specified by name in insert or update commands. In Delta 2.2 and below, only `INSERT *` or `UPDATE SET *` commands can be used for schema evolution with merge.
+<Aside type="note">
+  In Delta 2.3 and above, struct fields present in the source table can be specified by name in insert or update commands. In Delta 2.2 and below, only `INSERT *` or `UPDATE SET *` commands can be used for schema evolution with merge.
+</Aside>
 
 Here are a few examples of the effects of merge operations with and without schema evolution for arrays of structs.
 
@@ -493,28 +662,25 @@ You can reduce the time taken by merge using the following approaches:
 
 - **Reduce the search space for matches**: By default, the `merge` operation searches the entire Delta table to find matches in the source table. One way to speed up `merge` is to reduce the search space by adding known constraints in the match condition. For example, suppose you have a table that is partitioned by `country` and `date` and you want to use `merge` to update information for the last day and a specific country. Adding the condition
 
-  ```sql
-  events.date = current_date() AND events.country = 'USA'
-  ```
+  <Tabs syncKey="code-examples">
+    <TabItem label="SQL">
+
+      ```sql
+      events.date = current_date() AND events.country = 'USA'
+      ```
+    
+    </TabItem>
+  </Tabs>
 
   will make the query faster as it looks for matches only in the relevant partitions. Furthermore, it will also reduce the chances of conflicts with other concurrent operations. See [Concurrency control](/concurrency-control/) for more details.
 
 - **Compact files**: If the data is stored in many small files, reading the data to search for matches can become slow. You can compact small files into larger files to improve read throughput. See [Compact files](/best-practices/#compact-files) for details.
-
 - **Control the shuffle partitions for writes**: The `merge` operation shuffles data multiple times to compute and write the updated data. The number of tasks used to shuffle is controlled by the Spark session configuration `spark.sql.shuffle.partitions`. Setting this parameter not only controls the parallelism but also determines the number of output files. Increasing the value increases parallelism but also generates a larger number of smaller data files.
-
 - **Repartition output data before write**: For partitioned tables, `merge` can produce a much larger number of small files than the number of shuffle partitions. This is because every shuffle task can write multiple files in multiple partitions, and can become a performance bottleneck. In many cases, it helps to repartition the output data by the table's partition columns before writing it. You enable this by setting the Spark session configuration `spark.databricks.delta.merge.repartitionBeforeWrite.enabled` to `true`.
 
 ## Merge examples
 
 Here are a few examples on how to use `merge` in different scenarios.
-
-**In this section:**
-
-- [Data deduplication when writing into Delta tables](#data-deduplication-when-writing-into-delta-tables)
-- [Slowly changing data (SCD) Type 2 operation into Delta tables](#slowly-changing-data-scd-type-2-operation-into-delta-tables)
-- [Write change data into a Delta table](#write-change-data-into-a-delta-table)
-- [Upsert from streaming queries using `foreachBatch`](#upsert-from-streaming-queries-using-foreachbatch)
 
 ### Data deduplication when writing into Delta tables
 
@@ -522,47 +688,54 @@ A common ETL use case is to collect logs into Delta table by appending them to a
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`MERGE INTO logs
-USING newDedupedLogs
-ON logs.uniqueId = newDedupedLogs.uniqueId
-WHEN NOT MATCHED
-  THEN INSERT *`} lang="sql" />
+
+    ```sql
+    MERGE INTO logs
+    USING newDedupedLogs
+    ON logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS
+    WHEN NOT MATCHED AND newDedupedLogs.date > current_date() - INTERVAL 7 DAYS
+      THEN INSERT *
+    ```
+  
   </TabItem>
-
-<TabItem label="Python">
-  <Code
-    code={`deltaTable.alias("logs").merge(
-    newDedupedLogs.alias("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId") \\
-  .whenNotMatchedInsertAll() \\
-  .execute()`}
-    lang="python"
-  />
-</TabItem>
-
-<TabItem label="Scala">
-  <Code
-    code={`deltaTable
-  .as("logs")
-  .merge(
-    newDedupedLogs.as("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId")
-  .whenNotMatched()
-  .insertAll()
-  .execute()`}
-    lang="scala"
-  />
-</TabItem>
-
+  <TabItem label="Python">
+  
+    ```python
+    deltaTable.alias("logs").merge(
+      newDedupedLogs.alias("newDedupedLogs"),
+      "logs.uniqueId = newDedupedLogs.uniqueId") \
+    .whenNotMatchedInsertAll() \
+    .execute()
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    deltaTable
+      .as("logs")
+      .merge(
+        newDedupedLogs.as("newDedupedLogs"),
+        "logs.uniqueId = newDedupedLogs.uniqueId")
+      .whenNotMatched()
+      .insertAll()
+      .execute()
+    ```
+  
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`deltaTable
-  .as("logs")
-  .merge(
-    newDedupedLogs.as("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId")
-  .whenNotMatched()
-  .insertAll()
-  .execute();`} lang="java" />
+  
+    ```java
+    deltaTable
+      .as("logs")
+      .merge(
+        newDedupedLogs.as("newDedupedLogs"),
+        "logs.uniqueId = newDedupedLogs.uniqueId")
+      .whenNotMatched()
+      .insertAll()
+      .execute();
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -574,43 +747,50 @@ If you know that you may get duplicate records only for a few days, you can opti
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`MERGE INTO logs
-USING newDedupedLogs
-ON logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS
-WHEN NOT MATCHED AND newDedupedLogs.date > current_date() - INTERVAL 7 DAYS
-  THEN INSERT *`} lang="sql" />
+
+    ```sql
+    MERGE INTO logs
+    USING newDedupedLogs
+    ON logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS
+    WHEN NOT MATCHED AND newDedupedLogs.date > current_date() - INTERVAL 7 DAYS
+      THEN INSERT *
+    ```
+  
   </TabItem>
-
-<TabItem label="Python">
-  <Code
-    code={`deltaTable.alias("logs").merge(
-    newDedupedLogs.alias("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS") \\
-  .whenNotMatchedInsertAll("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS") \\
-  .execute()`}
-    lang="python"
-  />
-</TabItem>
-
-<TabItem label="Scala">
-  <Code
-    code={`deltaTable.as("logs").merge(
-    newDedupedLogs.as("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS")
-  .whenNotMatched("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS")
-  .insertAll()
-  .execute()`}
-    lang="scala"
-  />
-</TabItem>
-
+  <TabItem label="Python">
+  
+    ```python
+    deltaTable.alias("logs").merge(
+      newDedupedLogs.alias("newDedupedLogs"),
+      "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS") \
+    .whenNotMatchedInsertAll("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS") \
+    .execute()
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    deltaTable.as("logs").merge(
+      newDedupedLogs.as("newDedupedLogs"),
+      "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS")
+    .whenNotMatched("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS")
+    .insertAll()
+    .execute()
+    ```
+  
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`deltaTable.as("logs").merge(
-    newDedupedLogs.as("newDedupedLogs"),
-    "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS")
-  .whenNotMatched("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS")
-  .insertAll()
-  .execute();`} lang="java" />
+  
+    ```java
+    deltaTable.as("logs").merge(
+      newDedupedLogs.as("newDedupedLogs"),
+      "logs.uniqueId = newDedupedLogs.uniqueId AND logs.date > current_date() - INTERVAL 7 DAYS")
+    .whenNotMatched("newDedupedLogs.date > current_date() - INTERVAL 7 DAYS")
+    .insertAll()
+    .execute();
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -626,41 +806,92 @@ Another common operation is SCD Type 2, which maintains history of all changes m
 Here is a concrete example of maintaining the history of addresses for a customer along with the active date range of each address. When a customer's address needs to be updated, you have to mark the previous address as not the current one, update its active date range, and add the new address as the current one.
 
 <Tabs syncKey="code-examples">
-  <TabItem label="Scala">
-    <Code code={`val customersTable: DeltaTable = ...   // table with schema (customerId, address, current, effectiveDate, endDate)
-
-val updatesDF: DataFrame = ... // DataFrame with schema (customerId, address, effectiveDate)
-
-// Rows to INSERT new addresses of existing customers val newAddressesToInsert = updatesDF .as("updates") .join(customersTable.toDF.as("customers"), "customerid") .where("customers.current = true AND updates.address <> customers.address")`} lang="scala" />
-
-  </TabItem>
-
   <TabItem label="Python">
-    <Code code={`# Target: DeltaTable with schema (customerId, address, current, effectiveDate, endDate)
-customersTable = DeltaTable.forPath(spark, "/customers")
+  
+    ```python
+    customersTable = ...  # DeltaTable with schema (customerId, address, current, effectiveDate, endDate)
 
-# Source: DataFrame with schema (customerId, address, effectiveDate)
+    updatesDF = ...       # DataFrame with schema (customerId, address, effectiveDate)
 
-updatesDF = spark.read.format("delta").load("/updates")
+    # Rows to INSERT new addresses of existing customers
+    newAddressesToInsert = updatesDF \
+      .alias("updates") \
+      .join(customersTable.toDF().alias("customers"), "customerid") \
+      .where("customers.current = true AND updates.address <> customers.address")
 
-# Stage the update by unioning two sets of rows
+    # Stage the update by unioning two sets of rows
+    # 1. Rows that will be inserted in the whenNotMatched clause
+    # 2. Rows that will either update the current addresses of existing customers or insert the new addresses of new customers
+    stagedUpdates = (
+      newAddressesToInsert
+      .selectExpr("NULL as mergeKey", "updates.*")   # Rows for 1
+      .union(updatesDF.selectExpr("updates.customerId as mergeKey", "*"))  # Rows for 2.
+    )
 
-# 1. Rows that will be inserted in the merge
+    # Apply SCD Type 2 operation using merge
+    customersTable.alias("customers").merge(
+      stagedUpdates.alias("staged_updates"),
+      "customers.customerId = mergeKey") \
+    .whenMatchedUpdate(
+      condition = "customers.current = true AND customers.address <> staged_updates.address",
+      set = {                                      # Set current to false and endDate to source's effective date.
+        "current": "false",
+        "endDate": "staged_updates.effectiveDate"
+      }
+    ).whenNotMatchedInsert(
+      values = {
+        "customerid": "staged_updates.customerId",
+        "address": "staged_updates.address",
+        "current": "true",
+        "effectiveDate": "staged_updates.effectiveDate",  # Set current to true along with the new address and its effective date.
+        "endDate": "null"
+      }
+    ).execute()
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    val customersTable: DeltaTable = ...   // table with schema (customerId, address, current, effectiveDate, endDate)
 
-# 2. Rows that will be updated in the merge
+    val updatesDF: DataFrame = ...          // DataFrame with schema (customerId, address, effectiveDate)
 
-stagedUpdates = (
+    // Rows to INSERT new addresses of existing customers
+    val newAddressesToInsert = updatesDF
+      .as("updates")
+      .join(customersTable.toDF.as("customers"), "customerid")
+      .where("customers.current = true AND updates.address <> customers.address")
 
-# New rows to insert into customer table (for existing customers with new addresses)
+    // Stage the update by unioning two sets of rows
+    // 1. Rows that will be inserted in the whenNotMatched clause
+    // 2. Rows that will either update the current addresses of existing customers or insert the new addresses of new customers
+    val stagedUpdates = newAddressesToInsert
+      .selectExpr("NULL as mergeKey", "updates.*")   // Rows for 1.
+      .union(
+        updatesDF.selectExpr("updates.customerId as mergeKey", "*")  // Rows for 2.
+      )
 
-updatesDF.alias("updates") .join(customersTable.toDF().alias("customers"), "customerid") .where("customers.current = true AND updates.address <> customers.address") .selectExpr("NULL as mergeKey", "updates._") ).unionByName( # Rows to update (the latest addresses of existing customers) updatesDF.alias("updates") .join(customersTable.toDF().alias("customers"), "customerid") .where("customers.current = true AND updates.address <> customers.address") .selectExpr("customers.customerid as mergeKey", "updates._") )
-
-# Apply SCD Type 2 operation using merge
-
-customersTable.alias("customers").merge( stagedUpdates.alias("staged_updates"), "customers.customerid = mergeKey")
-
-.whenMatchedUpdate( condition = "customers.current = true AND customers.address <> staged_updates.address", set = { # Set current to false and endDate to source's effective date. "current": "false", "endDate": "staged_updates.effectiveDate" } ).whenNotMatchedInsert( values = { "customerid": "staged_updates.customerId", "address": "staged_updates.address", "current": "true", "effectiveDate": "staged_updates.effectiveDate", # Set current to true along with the new address and its effective date. "endDate": "null" } ).execute()`} lang="python" />
-
+    // Apply SCD Type 2 operation using merge
+    customersTable
+      .as("customers")
+      .merge(
+        stagedUpdates.as("staged_updates"),
+        "customers.customerId = mergeKey")
+      .whenMatched("customers.current = true AND customers.address <> staged_updates.address")
+      .updateExpr(Map(                                      // Set current to false and endDate to source's effective date.
+        "current" -> "false",
+        "endDate" -> "staged_updates.effectiveDate"))
+      .whenNotMatched()
+      .insertExpr(Map(
+        "customerid" -> "staged_updates.customerId",
+        "address" -> "staged_updates.address",
+        "current" -> "true",
+        "effectiveDate" -> "staged_updates.effectiveDate",  // Set current to true along with the new address and its effective date.
+        "endDate" -> "null"))
+      .execute()
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -669,52 +900,79 @@ customersTable.alias("customers").merge( stagedUpdates.alias("staged_updates"), 
 Similar to SCD, another common use case, often called change data capture (CDC), is to apply all data changes generated from an external database into a Delta table. In other words, a set of updates, deletes, and inserts applied to an external table needs to be applied to a Delta table. You can do this using `merge` as follows.
 
 <Tabs syncKey="code-examples">
-  <TabItem label="Scala">
-    <Code code={`val deltaTable: DeltaTable = ... // DeltaTable with schema (key, value)
-
-// DataFrame with changes having following columns // - key: key of the change // - time: time of change for ordering between changes (can replaced by other ordering id) // - newValue: updated or inserted value if key was not deleted // - deleted: true if the key was deleted, false if the key was inserted or updated val changesDF: DataFrame = ...
-
-// Find the latest change for each key based on the timestamp // Note: For nested structs, max on struct is computed as // max on first struct field, if equal fall back to second fields, and so on. val latestChangeForEachKey = changesDF .selectExpr("key", "struct(time, newValue, deleted) as otherCols" ) .groupBy("key") .agg(max("otherCols").as("latest")) .selectExpr("key", "latest.\*")
-
-deltaTable.as("t") .merge( latestChangeForEachKey.as("s"), "s.key = t.key") .whenMatched("s.deleted = true") .delete() .whenMatched() .updateExpr(Map("value" -> "s.newValue")) .whenNotMatched("s.deleted = false") .insertExpr(Map("key" -> "s.key", "value" -> "s.newValue")) .execute()`} lang="scala" />
-
-  </TabItem>
-
   <TabItem label="Python">
-    <Code code={`# DeltaTable with schema (key, value)
-deltaTable = DeltaTable.forPath(spark, "/delta-table")
+  
+    ```python
+    deltaTable = ... # DeltaTable with schema (key, value)
 
-# DataFrame with changes having following columns
+    # DataFrame with changes having following columns
+    # - key: key of the change
+    # - time: time of change for ordering between changes (can replaced by other ordering id)
+    # - newValue: updated or inserted value if key was not deleted
+    # - deleted: true if the key was deleted, false if the key was inserted or updated
+    changesDF = spark.table("changes")
 
-# - key: key of the change
+    # Find the latest change for each key based on the timestamp
+    # Note: For nested structs, max on struct is computed as
+    # max on first struct field, if equal fall back to second fields, and so on.
+    latestChangeForEachKey = changesDF \
+      .selectExpr("key", "struct(time, newValue, deleted) as otherCols") \
+      .groupBy("key") \
+      .agg(max("otherCols").alias("latest")) \
+      .select("key", "latest.*") \
 
-# - time: time of change for ordering between changes (can replaced by other ordering id)
+    deltaTable.alias("t").merge(
+        latestChangeForEachKey.alias("s"),
+        "s.key = t.key") \
+      .whenMatchedDelete(condition = "s.deleted = true") \
+      .whenMatchedUpdate(set = {
+        "key": "s.key",
+        "value": "s.newValue"
+      }) \
+      .whenNotMatchedInsert(
+        condition = "s.deleted = false",
+        values = {
+          "key": "s.key",
+          "value": "s.newValue"
+        }
+      ).execute()
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    val deltaTable: DeltaTable = ... // DeltaTable with schema (key, value)
 
-# - newValue: updated or inserted value if key was not deleted
+    // DataFrame with changes having following columns
+    // - key: key of the change
+    // - time: time of change for ordering between changes (can replaced by other ordering id)
+    // - newValue: updated or inserted value if key was not deleted
+    // - deleted: true if the key was deleted, false if the key was inserted or updated
+    val changesDF: DataFrame = ...
 
-# - deleted: true if the key was deleted, false if the key was inserted or updated
+    // Find the latest change for each key based on the timestamp
+    // Note: For nested structs, max on struct is computed as
+    // max on first struct field, if equal fall back to second fields, and so on.
+    val latestChangeForEachKey = changesDF
+      .selectExpr("key", "struct(time, newValue, deleted) as otherCols" )
+      .groupBy("key")
+      .agg(max("otherCols").as("latest"))
+      .selectExpr("key", "latest.*")
 
-changesDF = spark.read.format("json").load("/changes")
-
-# Find the latest change for each key based on the timestamp
-
-# Note: For nested structs, max on struct is computed as
-
-# max on first struct field, if equal fall back to second fields, and so on.
-
-latestChangeForEachKey = changesDF \
- .selectExpr("key", "struct(time, newValue, deleted) as otherCols") \
- .groupBy("key") \
- .agg(expr("max(otherCols) as latest")) \
- .selectExpr("key", "latest.\*")
-
-deltaTable.alias("t") \
- .merge( latestChangeForEachKey.alias("s"), "s.key = t.key") \
- .whenMatchedDelete("s.deleted = true") \
- .whenMatchedUpdateExpr({"value": "s.newValue"}) \
- .whenNotMatchedInsertExpr( condition = "s.deleted = false", values = { "key": "s.key", "value": "s.newValue" } ) \
- .execute()`} lang="python" />
-
+    deltaTable.as("t")
+      .merge(
+        latestChangeForEachKey.as("s"),
+        "s.key = t.key")
+      .whenMatched("s.deleted = true")
+      .delete()
+      .whenMatched()
+      .updateExpr(Map("key" -> "s.key", "value" -> "s.newValue"))
+      .whenNotMatched("s.deleted = false")
+      .insertExpr(Map("key" -> "s.key", "value" -> "s.newValue"))
+      .execute()
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -724,33 +982,61 @@ You can use a combination of `merge` and `foreachBatch` (see [foreachbatch](http
 
 - **Write streaming aggregates in Update Mode**: This is much more efficient than Complete Mode.
 
-<Tabs syncKey="code-examples">
-  <TabItem label="Scala">
-    <Code code={`import io.delta.tables.*
+  <Tabs syncKey="code-examples">
+    <TabItem label="Python">
+    
+      ```python
+      from delta.tables import *
 
-val deltaTable = DeltaTable.forPath(spark, "/data/aggregates")
+      deltaTable = DeltaTable.forPath(spark, "/data/aggregates")
 
-def upsertToDelta(microBatchOutputDF: DataFrame, batchId: Long) { deltaTable.as("t") .merge( microBatchOutputDF.as("s"), "s.key = t.key") .whenMatched().updateAll() .whenNotMatched().insertAll() .execute() }
+      # Function to upsert microBatchOutputDF into Delta table using merge
+      def upsertToDelta(microBatchOutputDF, batchId):
+        deltaTable.alias("t").merge(
+            microBatchOutputDF.alias("s"),
+            "s.key = t.key") \
+          .whenMatchedUpdateAll() \
+          .whenNotMatchedInsertAll() \
+          .execute()
+      }
 
-// Write the output of a streaming aggregation query into Delta table streamingAggregatesDF.writeStream .format("delta") .foreachBatch(upsertToDelta \_) .outputMode("update") .start()`} lang="scala" />
+      # Write the output of a streaming aggregation query into Delta table
+      streamingAggregatesDF.writeStream \
+        .format("delta") \
+        .foreachBatch(upsertToDelta) \
+        .outputMode("update") \
+        .start()
+      ```
+    
+    </TabItem>
+    <TabItem label="Scala">
+    
+      ```scala
+      import io.delta.tables.*
 
-  </TabItem>
+      val deltaTable = DeltaTable.forPath(spark, "/data/aggregates")
 
-  <TabItem label="Python">
-    <Code code={`from delta.tables import *
+      // Function to upsert microBatchOutputDF into Delta table using merge
+      def upsertToDelta(microBatchOutputDF: DataFrame, batchId: Long) {
+        deltaTable.as("t")
+          .merge(
+            microBatchOutputDF.as("s"),
+            "s.key = t.key")
+          .whenMatched().updateAll()
+          .whenNotMatched().insertAll()
+          .execute()
+      }
 
-deltaTable = DeltaTable.forPath(spark, "/data/aggregates")
-
-# Function to upsert microBatchOutputDF into Delta table using merge
-
-def upsertToDelta(microBatchOutputDF, batchId): deltaTable.alias("t").merge( microBatchOutputDF.alias("s"), "s.key = t.key") \\ .whenMatchedUpdateAll() \\ .whenNotMatchedInsertAll() \\ .execute()
-
-# Write the output of a streaming aggregation query into Delta table
-
-streamingAggregatesDF.writeStream \\ .format("delta") \\ .foreachBatch(upsertToDelta) \\ .outputMode("update") \\ .start()`} lang="python" />
-
-  </TabItem>
-</Tabs>
+      // Write the output of a streaming aggregation query into Delta table
+      streamingAggregatesDF.writeStream
+        .format("delta")
+        .foreachBatch(upsertToDelta _)
+        .outputMode("update")
+        .start()
+      ```
+    
+    </TabItem>
+  </Tabs>
 
 - **Write a stream of database changes into a Delta table**: The [merge query for writing change data](#write-change-data-into-a-delta-table) can be used in `foreachBatch` to continuously apply a stream of changes to a Delta table.
 - **Write a stream data into Delta table with deduplication**: The [insert-only merge query for deduplication](#data-deduplication-when-writing-into-delta-tables) can be used in `foreachBatch` to continuously write data (with duplicates) to a Delta table with automatic deduplication.

--- a/src/content/docs/delta-utility/index.mdx
+++ b/src/content/docs/delta-utility/index.mdx
@@ -3,7 +3,7 @@ title: Table utility commands
 description: Learn about Delta Lake utility commands.
 ---
 
-import { Tabs, TabItem, Aside, Code } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { Image } from "astro:assets";
 
 Delta tables support a number of utility commands.

--- a/src/content/docs/delta-utility/index.mdx
+++ b/src/content/docs/delta-utility/index.mdx
@@ -3,8 +3,7 @@ title: Table utility commands
 description: Learn about Delta Lake utility commands.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
-import { Image } from "astro:assets";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Delta tables support a number of utility commands.
 
@@ -21,68 +20,82 @@ You can remove files no longer referenced by a Delta table and are older than th
   - `vacuum` removes all files from directories not managed by Delta Lake,
   ignoring directories beginning with `_`. If you are storing additional
   metadata like Structured Streaming checkpoints within a Delta table directory,
-  use a directory name such as `_checkpoints`. - `vacuum` deletes only data
-  files, not log files. Log files are deleted automatically and asynchronously
+  use a directory name such as `_checkpoints`.
+  - `vacuum` deletes only data files, not log files. Log files are deleted automatically and asynchronously
   after checkpoint operations. The default retention period of log files is 30
   days, configurable through the `delta.logRetentionDuration` property which you
   set with the `ALTER TABLE SET TBLPROPERTIES` SQL method. See [Table
-  properties](/delta-batch/#table-properties). - The ability to [time
-  travel](/delta-batch/#query-an-older-snapshot-of-a-table-time-travel) back to
+  properties](/delta-batch/#table-properties).
+  - The ability to [time travel](/delta-batch/#query-an-older-snapshot-of-a-table-time-travel) back to
   a version older than the retention period is lost after running `vacuum`.
 </Aside>
 
+
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`VACUUM eventsTable   -- This runs VACUUM in 'FULL' mode and deletes data files outside of the retention duration and all files in the table directory not referenced by the table.
+  
+    ```sql
+    VACUUM eventsTable   -- This runs VACUUM in ‘FULL’ mode and deletes data files outside of the retention duration and all files in the table directory not referenced by the table.
 
-VACUUM eventsTable LITE -- This VACUUM in 'LITE' mode runs faster. -- Instead of finding all files in the table directory, \`VACUUM LITE\` uses the Delta transaction log to identify and remove files no longer referenced by any table versions within the retention duration. -- If \`VACUUM LITE\` cannot be completed because the Delta log has been pruned a \`DELTA_CANNOT_VACUUM_LITE\` exception is raised. -- This mode is available only in Delta 3.3 and above.
+    VACUUM eventsTable LITE   -- This VACUUM in ‘LITE’ mode runs faster.
+                              -- Instead of finding all files in the table directory, `VACUUM LITE` uses the Delta transaction log to identify and remove files no longer referenced by any table versions within the retention duration.
+                              -- If `VACUUM LITE` cannot be completed because the Delta log has been pruned a `DELTA_CANNOT_VACUUM_LITE` exception is raised.
+                              -- This mode is available only in Delta 3.3 and above.
 
-VACUUM '/data/events' -- vacuum files in path-based table
+    VACUUM '/data/events' -- vacuum files in path-based table
 
-VACUUM delta.\`/data/events/\`
+    VACUUM delta.`/data/events/`
 
-VACUUM delta.\`/data/events/\` RETAIN 100 HOURS -- vacuum files not required by versions more than 100 hours old
+    VACUUM delta.`/data/events/` RETAIN 100 HOURS  -- vacuum files not required by versions more than 100 hours old
 
-VACUUM eventsTable DRY RUN -- do dry run to get the list of files to be deleted
+    VACUUM eventsTable DRY RUN    -- do dry run to get the list of files to be deleted
 
-VACUUM eventsTable USING INVENTORY inventoryTable —- vacuum files based on a provided reservoir of files as a delta table
+    VACUUM eventsTable USING INVENTORY inventoryTable  —- vacuum files based on a provided reservoir of files as a delta table
 
-VACUUM eventsTable USING INVENTORY (select \* from inventoryTable) —- vacuum files based on a provided reservoir of files as spark SQL query`} lang="sql" />
-
+    VACUUM eventsTable USING INVENTORY (select * from inventoryTable)  —- vacuum files based on a provided reservoir of files as spark SQL query
+    ```
+  
   </TabItem>
-
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
+  
+    ```python
+    from delta.tables import *
 
-deltaTable = DeltaTable.forPath(spark, pathToTable) # path-based tables, or deltaTable = DeltaTable.forName(spark, tableName) # Hive metastore-based tables
+    deltaTable = DeltaTable.forPath(spark, pathToTable)  # path-based tables, or
+    deltaTable = DeltaTable.forName(spark, tableName)    # Hive metastore-based tables
 
-deltaTable.vacuum() # vacuum files not required by versions older than the default retention period
+    deltaTable.vacuum()        # vacuum files not required by versions older than the default retention period
 
-deltaTable.vacuum(100) # vacuum files not required by versions more than 100 hours old`} lang="python" />
-
+    deltaTable.vacuum(100)     # vacuum files not required by versions more than 100 hours old
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, pathToTable)
+    val deltaTable = DeltaTable.forPath(spark, pathToTable)
 
-deltaTable.vacuum() // vacuum files not required by versions older than the default retention period
+    deltaTable.vacuum()        // vacuum files not required by versions older than the default retention period
 
-deltaTable.vacuum(100) // vacuum files not required by versions more than 100 hours old`} lang="scala" />
-
+    deltaTable.vacuum(100)     // vacuum files not required by versions more than 100 hours old
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
-import org.apache.spark.sql.functions;
+  
+    ```java
+    import io.delta.tables.*;
+    import org.apache.spark.sql.functions;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
+    DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
 
-deltaTable.vacuum(); // vacuum files not required by versions older than the default retention period
+    deltaTable.vacuum();        // vacuum files not required by versions older than the default retention period
 
-deltaTable.vacuum(100); // vacuum files not required by versions more than 100 hours old`} lang="java" />
-
+    deltaTable.vacuum(100);     // vacuum files not required by versions more than 100 hours old
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -95,16 +108,15 @@ deltaTable.vacuum(100); // vacuum files not required by versions more than 100 h
 See the [Delta Lake APIs](/delta-apidoc/) for Scala, Java, and Python syntax details.
 
 <Aside type="caution">
-It is recommended that you set a retention interval to be at least 7 days,
-because old snapshots and uncommitted files can still be in use by concurrent
-readers or writers to the table. If `VACUUM` cleans up active files,
-concurrent readers can fail or, worse, tables can be corrupted when `VACUUM`
-deletes files that have not yet been committed. You must choose an interval
-that is longer than the longest running concurrent transaction and the longest
-period that any stream can lag behind the most recent update to the table.
+  It is recommended that you set a retention interval to be at least 7 days,
+  because old snapshots and uncommitted files can still be in use by concurrent
+  readers or writers to the table. If `VACUUM` cleans up active files,
+  concurrent readers can fail or, worse, tables can be corrupted when `VACUUM`
+  deletes files that have not yet been committed. You must choose an interval
+  that is longer than the longest running concurrent transaction and the longest
+  period that any stream can lag behind the most recent update to the table.
 
-Delta Lake has a safety check to prevent you from running a dangerous `VACUUM` command. If you are certain that there are no operations being performed on this table that take longer than the retention interval you plan to specify, you can turn off this safety check by setting the Spark configuration property `spark.databricks.delta.retentionDurationCheck.enabled` to `false`.
-
+  Delta Lake has a safety check to prevent you from running a dangerous `VACUUM` command. If you are certain that there are no operations being performed on this table that take longer than the retention interval you plan to specify, you can turn off this safety check by setting the Spark configuration property `spark.databricks.delta.retentionDurationCheck.enabled` to `false`.
 </Aside>
 
 ### Inventory Table
@@ -122,49 +134,60 @@ An inventory table contains a list of file paths together with their size, type 
 
 You can retrieve information on the operations, user, timestamp, and so on for each write to a Delta table by running the `history` command. The operations are returned in reverse chronological order. By default table history is retained for 30 days.
 
-**SQL**
-
-```sql
-DESCRIBE HISTORY '/data/events/'          -- get the full history of the table
-
-DESCRIBE HISTORY delta.`/data/events/`
-
-DESCRIBE HISTORY '/data/events/' LIMIT 1  -- get the last operation only
-
-DESCRIBE HISTORY eventsTable
-```
-
 See [Configure SparkSession](/delta-batch/#configure-sparksession) for the steps to enable support for SQL commands in Apache Spark.
 
-<Tabs>
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL">
+  
+    ```sql
+    DESCRIBE HISTORY '/data/events/'          -- get the full history of the table
+
+    DESCRIBE HISTORY delta.`/data/events/`
+
+    DESCRIBE HISTORY '/data/events/' LIMIT 1  -- get the last operation only
+
+    DESCRIBE HISTORY eventsTable
+    ```
+  
+  </TabItem>
   <TabItem label="Python">
-    <Code
-      code={`from delta.tables import *
+  
+    ```python
+    from delta.tables import *
 
-deltaTable = DeltaTable.forPath(spark, pathToTable)
+    deltaTable = DeltaTable.forPath(spark, pathToTable)
 
-detailDF = deltaTable.detail()`} lang="python" />
+    fullHistoryDF = deltaTable.history()    # get the full history of the table
 
+    lastOperationDF = deltaTable.history(1) # get the last operation
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code
-      code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, pathToTable)
+    val deltaTable = DeltaTable.forPath(spark, pathToTable)
 
-val detailDF = deltaTable.detail()`} lang="scala" />
+    val fullHistoryDF = deltaTable.history()    // get the full history of the table
 
+    val lastOperationDF = deltaTable.history(1) // get the last operation
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code
-      code={`import io.delta.tables.*;
+  
+    ```java
+    import io.delta.tables.*;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
+    DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
 
-DataFrame detailDF = deltaTable.detail();`} lang="java" />
+    DataFrame fullHistoryDF = deltaTable.history();       // get the full history of the table
 
+    DataFrame lastOperationDF = deltaTable.history(1);    // fetch the last operation on the DeltaTable
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -203,7 +226,7 @@ The output of the `history` operation has the following columns.
 ```
 
 <Aside type="note">
-  - Some of the columns may be nulls because the corresponding information may
+  Some of the columns may be nulls because the corresponding information may
   not be available in your environment. - Columns added in the future will
   always be added after the last column.
 </Aside>
@@ -270,9 +293,6 @@ The following table lists the map key definitions by operation.
 |  | numDeletedFiles | Number of deleted files. |
 |  | numVacuumedDirectories | Number of vacuumed directories. |
 |  | numFilesToDelete | Number of files to delete. |
-
-| Operation | Metric name | Description |
-| :-- | :-- | :-- |
 | RESTORE |  |  |
 |  | tableSizeAfterRestore | Table size in bytes after restore. |
 |  | numOfFilesAfterRestore | Number of files in the table after restore. |
@@ -285,45 +305,50 @@ The following table lists the map key definitions by operation.
 
 You can retrieve detailed information about a Delta table (for example, number of files, data size) using `DESCRIBE DETAIL`.
 
-**SQL**
-
-```sql
-DESCRIBE DETAIL '/data/events/'
-
-DESCRIBE DETAIL eventsTable
-```
-
 See [Configure SparkSession](/delta-batch/#configure-sparksession) for the steps to enable support for SQL commands in Apache Spark.
 
-<Tabs>
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL">
+  
+    ```sql
+    DESCRIBE DETAIL '/data/events/'
+
+    DESCRIBE DETAIL eventsTable
+    ```
+  
+  </TabItem>
   <TabItem label="Python">
-    <Code
-      code={`from delta.tables import *
+  
+    ```python
+    from delta.tables import *
 
-deltaTable = DeltaTable.forPath(spark, pathToTable)
+    deltaTable = DeltaTable.forPath(spark, pathToTable)
 
-detailDF = deltaTable.detail()`} lang="python" />
-
+    detailDF = deltaTable.detail()
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code
-      code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, pathToTable)
+    val deltaTable = DeltaTable.forPath(spark, pathToTable)
 
-val detailDF = deltaTable.detail()`} lang="scala" />
-
+    val detailDF = deltaTable.detail()
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code
-      code={`import io.delta.tables.*;
+  
+    ```java
+    import io.delta.tables.*;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
+    DeltaTable deltaTable = DeltaTable.forPath(spark, pathToTable);
 
-DataFrame detailDF = deltaTable.detail();`} lang="java" />
-
+    DataFrame detailDF = deltaTable.detail();
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -361,28 +386,35 @@ You can a generate manifest file for a Delta table that can be used by other pro
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`GENERATE symlink_format_manifest FOR TABLE delta.\`<path-to-delta-table>\``} lang="sql" />
+  
+    ```sql
+    GENERATE symlink_format_manifest FOR TABLE delta.`<path-to-delta-table>`
+    ```
+  
   </TabItem>
-
-<TabItem label="Python">
-  <Code
-    code={`deltaTable = DeltaTable.forPath(<path-to-delta-table>)
-deltaTable.generate("symlink_format_manifest")`}
-    lang="python"
-  />
-</TabItem>
-
-<TabItem label="Scala">
-  <Code
-    code={`val deltaTable = DeltaTable.forPath(<path-to-delta-table>)
-deltaTable.generate("symlink_format_manifest")`}
-    lang="scala"
-  />
-</TabItem>
-
+  <TabItem label="Python">
+  
+    ```python
+    deltaTable = DeltaTable.forPath(<path-to-delta-table>)
+    deltaTable.generate("symlink_format_manifest")
+    ```
+  
+  </TabItem>
+  <TabItem label="Scala">
+  
+    ```scala
+    val deltaTable = DeltaTable.forPath(<path-to-delta-table>)
+    deltaTable.generate("symlink_format_manifest")
+    ```
+  
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`DeltaTable deltaTable = DeltaTable.forPath(<path-to-delta-table>);
-deltaTable.generate("symlink_format_manifest");`} lang="java" />
+  
+    ```java
+    DeltaTable deltaTable = DeltaTable.forPath(<path-to-delta-table>);
+    deltaTable.generate("symlink_format_manifest");
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -403,46 +435,60 @@ By default, this command will collect per-file statistics (e.g. minimum and maxi
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`-- Convert unpartitioned Parquet table at path '<path-to-table>'
-CONVERT TO DELTA parquet.\`<path-to-table>\`
+  
+    ```sql
+    -- Convert unpartitioned Parquet table at path '<path-to-table>'
+    CONVERT TO DELTA parquet.`<path-to-table>`
 
--- Convert unpartitioned Parquet table and disable statistics collection CONVERT TO DELTA parquet.\`<path-to-table>\` NO STATISTICS
+    -- Convert unpartitioned Parquet table and disable statistics collection
+    CONVERT TO DELTA parquet.`<path-to-table>` NO STATISTICS
 
--- Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2' CONVERT TO DELTA parquet.\`<path-to-table>\` PARTITIONED BY (part int, part2 int)
+    -- Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2'
+    CONVERT TO DELTA parquet.`<path-to-table>` PARTITIONED BY (part int, part2 int)
 
--- Convert partitioned Parquet table and disable statistics collection CONVERT TO DELTA parquet.\`<path-to-table>\` NO STATISTICS PARTITIONED BY (part int, part2 int)`} lang="sql" />
-
+    -- Convert partitioned Parquet table and disable statistics collection
+    CONVERT TO DELTA parquet.`<path-to-table>` NO STATISTICS PARTITIONED BY (part int, part2 int)
+    ```
+  
   </TabItem>
-
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
+  
+    ```python
+    from delta.tables import *
 
-# Convert unpartitioned Parquet table at path '<path-to-table>'
+    # Convert unpartitioned Parquet table at path '<path-to-table>'
+    deltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`")
 
-deltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`")
-
-# Convert partitioned parquet table at path '<path-to-table>' and partitioned by integer column named 'part'
-
-partitionedDeltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`", "part int")`} lang="python" />
-
+    # Convert partitioned parquet table at path '<path-to-table>' and partitioned by integer column named 'part'
+    partitionedDeltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`", "part int")
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-// Convert unpartitioned Parquet table at path '<path-to-table>' val deltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`")
+    // Convert unpartitioned Parquet table at path '<path-to-table>'
+    val deltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`")
 
-// Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2' val partitionedDeltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`", "part int, part2 int")`} lang="scala" />
-
+    // Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2'
+    val partitionedDeltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`", "part int, part2 int")
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
+  
+    ```java
+    import io.delta.tables.*;
 
-// Convert unpartitioned Parquet table at path '<path-to-table>' DeltaTable deltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`");
+    // Convert unpartitioned Parquet table at path '<path-to-table>'
+    DeltaTable deltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`");
 
-// Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2' DeltaTable deltaTable = DeltaTable.convertToDelta(spark, "parquet.\`<path-to-table>\`", "part int, part2 int");`} lang="java" />
-
+    // Convert partitioned Parquet table at path '<path-to-table>' and partitioned by integer columns named 'part' and 'part2'
+    DeltaTable deltaTable = DeltaTable.convertToDelta(spark, "parquet.`<path-to-table>`", "part int, part2 int");
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -461,23 +507,28 @@ You can convert an Iceberg table to a Delta table in place if the underlying fil
 
 The following command creates a Delta Lake transaction log based on the Iceberg table's native file manifest, schema and partitioning information. The converter also collects column stats during the conversion, unless `NO STATISTICS` is specified.
 
-```sql
--- Convert the Iceberg table in the path <path-to-table>.
-CONVERT TO DELTA iceberg.\`<path-to-table>\`
+<Tabs syncKey="code-examples">
+  <TabItem label="SQL">
 
--- Convert the Iceberg table in the path <path-to-table> without collecting statistics.
-CONVERT TO DELTA iceberg.\`<path-to-table>\` NO STATISTICS
-```
+    ```sql
+    -- Convert the Iceberg table in the path <path-to-table>.
+    CONVERT TO DELTA iceberg.\`<path-to-table>\`
+
+    -- Convert the Iceberg table in the path <path-to-table> without collecting statistics.
+    CONVERT TO DELTA iceberg.\`<path-to-table>\` NO STATISTICS
+    ```
+  
+  </TabItem>
+</Tabs>
 
 <Aside type="caution" title="Important">
-An additional jar `delta-iceberg` is needed to use the converter. For example, `bin/spark-sql --packages io.delta:delta-spark_2.12:3.0.0,io.delta:delta-iceberg_2.12:3.0.0:...`.
+  An additional jar `delta-iceberg` is needed to use the converter. For example, `bin/spark-sql --packages io.delta:delta-spark_2.12:3.0.0,io.delta:delta-iceberg_2.12:3.0.0:...`.
 
-`delta-iceberg` is currently not available for the Delta Lake 2.4.0 release since `iceberg-spark-runtime` does not support Spark 3.4 yet. It is available for Delta Lake 2.3.0.
-
+  `delta-iceberg` is currently not available for the Delta Lake 2.4.0 release since `iceberg-spark-runtime` does not support Spark 3.4 yet. It is available for Delta Lake 2.3.0.
 </Aside>
 
 <Aside type="note">
-  - Converting Iceberg metastore tables is not supported. - Converting Iceberg
+  Converting Iceberg metastore tables is not supported. - Converting Iceberg
   tables that have experienced [partition
   evolution](https://iceberg.apache.org/docs/latest/evolution/#partition-evolution)
   is not supported. - Converting Iceberg merge-on-read tables that have
@@ -499,51 +550,66 @@ You can restore a Delta table to its earlier state by using the `RESTORE` comman
   type="caution"
   title="Important"
 >
-  - You can restore an already restored table. - Restoring a table to an older
+  - You can restore an already restored table.
+  - Restoring a table to an older
   version where the data files were deleted manually or by `vacuum` will fail.
   Restoring to this version partially is still possible if
-  `spark.sql.files.ignoreMissingFiles` is set to `true`. - The timestamp format
+  `spark.sql.files.ignoreMissingFiles` is set to `true`.
+  - The timestamp format
   for restoring to an earlier state is `yyyy-MM-dd HH:mm:ss`. Providing only a
   date(`yyyy-MM-dd`) string is also supported.
 </Aside>
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`RESTORE TABLE db.target_table TO VERSION AS OF <version>
-RESTORE TABLE delta.\`/data/target/\` TO TIMESTAMP AS OF <timestamp>`} lang="sql" />
+  
+    ```sql
+    RESTORE TABLE db.target_table TO VERSION AS OF <version>
+    RESTORE TABLE delta.`/data/target/` TO TIMESTAMP AS OF <timestamp>
+    ```
+  
   </TabItem>
-
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
+  
+    ```python
+    from delta.tables import *
 
-deltaTable = DeltaTable.forPath(spark, <path-to-table>) # path-based tables, or deltaTable = DeltaTable.forName(spark, <table-name>) # Hive metastore-based tables
+    deltaTable = DeltaTable.forPath(spark, <path-to-table>)  # path-based tables, or
+    deltaTable = DeltaTable.forName(spark, <table-name>)    # Hive metastore-based tables
 
-deltaTable.restoreToVersion(0) # restore table to oldest version
+    deltaTable.restoreToVersion(0) # restore table to oldest version
 
-deltaTable.restoreToTimestamp('2019-02-14') # restore to a specific timestamp`} lang="python" />
-
+    deltaTable.restoreToTimestamp('2019-02-14') # restore to a specific timestamp
+    ```
+  
   </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
+  
+    ```scala
+    import io.delta.tables._
 
-val deltaTable = DeltaTable.forPath(spark, <path-to-table>) val deltaTable = DeltaTable.forName(spark, <table-name>)
+    val deltaTable = DeltaTable.forPath(spark, <path-to-table>)
+    val deltaTable = DeltaTable.forName(spark, <table-name>)
 
-deltaTable.restoreToVersion(0) // restore table to oldest version
+    deltaTable.restoreToVersion(0) // restore table to oldest version
 
-deltaTable.restoreToTimestamp("2019-02-14") // restore to a specific timestamp`} lang="scala" />
-
+    deltaTable.restoreToTimestamp("2019-02-14") // restore to a specific timestamp
+    ```
+  
   </TabItem>
-
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
+  
+    ```java
+    import io.delta.tables.*;
 
-DeltaTable deltaTable = DeltaTable.forPath(spark, <path-to-table>); DeltaTable deltaTable = DeltaTable.forName(spark, <table-name>);
+    DeltaTable deltaTable = DeltaTable.forPath(spark, <path-to-table>);
+    DeltaTable deltaTable = DeltaTable.forName(spark, <table-name>);
 
-deltaTable.restoreToVersion(0) // restore table to oldest version
+    deltaTable.restoreToVersion(0) // restore table to oldest version
 
-deltaTable.restoreToTimestamp("2019-02-14") // restore to a specific timestamp`} lang="java" />
-
+    deltaTable.restoreToTimestamp("2019-02-14") // restore to a specific timestamp
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -600,16 +666,20 @@ The metadata that is cloned includes: schema, partitioning information, invarian
   `vacuum` on the source table, clients will no longer be able to read the
   referenced data files and a `FileNotFoundException` will be thrown. In this
   case, running clone with `replace` over the shallow clone will repair the
-  clone. - If a target already has a non-Delta table at that path, cloning with
+  clone.
+  - If a target already has a non-Delta table at that path, cloning with
   `replace` to that target will create a Delta log. Then, you can clean up any
-  existing data by running `vacuum`. - If a Delta table exists in the target
+  existing data by running `vacuum`.
+  - If a Delta table exists in the target
   path, a new commit is created that includes the new metadata and new data from
   the source table. In the case of `replace`, the target table needs to be
-  emptied first to avoid data duplication. - Cloning a table is not the same as
+  emptied first to avoid data duplication.
+  - Cloning a table is not the same as
   `Create Table As Select` or `CTAS`. A shallow clone takes the metadata of the
   source table. Cloning also has simpler syntax: you don't need to specify
   partitioning, format, invariants, nullability and so on as they are taken from
-  the source table. - A cloned table has an independent history from its source
+  the source table.
+  - A cloned table has an independent history from its source
   table. Time travel queries on a cloned table will not work with the same
   inputs as they work on its source table. For example, if the source table was
   at version 100 and we are creating a new table by cloning it, the new table
@@ -619,18 +689,21 @@ The metadata that is cloned includes: schema, partitioning information, invarian
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`CREATE TABLE delta.\`/data/target/\` SHALLOW CLONE delta.\`/data/source/\` -- Create a shallow clone of /data/source at /data/target
+  
+    ```sql
+    CREATE TABLE delta.`/data/target/` SHALLOW CLONE delta.`/data/source/` -- Create a shallow clone of /data/source at /data/target
 
-CREATE OR REPLACE TABLE db.target_table SHALLOW CLONE db.source_table -- Replace the target. target needs to be emptied
+    CREATE OR REPLACE TABLE db.target_table SHALLOW CLONE db.source_table -- Replace the target. target needs to be emptied
 
-CREATE TABLE IF NOT EXISTS delta.\`/data/target/\` SHALLOW CLONE db.source_table -- No-op if the target table exists
+    CREATE TABLE IF NOT EXISTS delta.`/data/target/` SHALLOW CLONE db.source_table -- No-op if the target table exists
 
-CREATE TABLE db.target_table SHALLOW CLONE delta.\`/data/source\`
+    CREATE TABLE db.target_table SHALLOW CLONE delta.`/data/source`
 
-CREATE TABLE db.target_table SHALLOW CLONE delta.\`/data/source\` VERSION AS OF version
+    CREATE TABLE db.target_table SHALLOW CLONE delta.`/data/source` VERSION AS OF version
 
-CREATE TABLE db.target_table SHALLOW CLONE delta.\`/data/source\` TIMESTAMP AS OF timestamp_expression -- timestamp can be like "2019-01-01" or like date_sub(current_date(), 1)`} lang="sql" />
-
+    CREATE TABLE db.target_table SHALLOW CLONE delta.`/data/source` TIMESTAMP AS OF timestamp_expression -- timestamp can be like “2019-01-01” or like date_sub(current_date(), 1)
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -651,11 +724,12 @@ When doing machine learning, you may want to archive a certain version of a tabl
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code
-      code={`-- Trained model on version 15 of Delta table
-CREATE TABLE delta.\`/model/dataset\` SHALLOW CLONE entire_dataset VERSION AS OF 15`}
-      lang="sql"
-    />
+  
+    ```sql
+    -- Trained model on version 15 of Delta table
+    CREATE TABLE delta.`/model/dataset` SHALLOW CLONE entire_dataset VERSION AS OF 15
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -665,15 +739,24 @@ To test a workflow on a production table without corrupting the table, you can e
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`-- Perform shallow clone
-CREATE OR REPLACE TABLE my_test SHALLOW CLONE my_prod_table;
+  
+    ```sql
+    -- Perform shallow clone
+    CREATE OR REPLACE TABLE my_test SHALLOW CLONE my_prod_table;
 
-UPDATE my_test WHERE user_id is null SET invalid=true; -- Run a bunch of validations. Once happy:
+    UPDATE my_test WHERE user_id is null SET invalid=true;
+    -- Run a bunch of validations. Once happy:
 
--- This should leverage the update information in the clone to prune to only -- changed files in the clone if possible MERGE INTO my_prod_table USING my_test ON my_test.user_id <=> my_prod_table.user_id WHEN MATCHED AND my_test.user_id is null THEN UPDATE \*;
+    -- This should leverage the update information in the clone to prune to only
+    -- changed files in the clone if possible
+    MERGE INTO my_prod_table
+    USING my_test
+    ON my_test.user_id <=> my_prod_table.user_id
+    WHEN MATCHED AND my_test.user_id is null THEN UPDATE *;
 
-DROP TABLE my_test;`} lang="sql" />
-
+    DROP TABLE my_test;
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -686,15 +769,16 @@ Table property overrides are particularly useful for:
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code
-      code={`CREATE OR REPLACE TABLE archive.my_table SHALLOW CLONE prod.my_table
-TBLPROPERTIES (
-  delta.logRetentionDuration = '3650 days',
-  delta.deletedFileRetentionDuration = '3650 days'
-)
-LOCATION 'xx://archive/my_table'`}
-      lang="sql"
-    />
+  
+    ```sql
+    CREATE OR REPLACE TABLE archive.my_table SHALLOW CLONE prod.my_table
+    TBLPROPERTIES (
+      delta.logRetentionDuration = '3650 days',
+      delta.deletedFileRetentionDuration = '3650 days'
+    )
+    LOCATION 'xx://archive/my_table'
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -708,9 +792,12 @@ Shallow clone for Parquet and Iceberg combines functionality used to clone Delta
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`CREATE OR REPLACE TABLE <target_table_name> SHALLOW CLONE parquet.\`/path/to/data\`;
+  
+    ```sql
+    CREATE OR REPLACE TABLE <target_table_name> SHALLOW CLONE parquet.`/path/to/data`;
 
-CREATE OR REPLACE TABLE <target_table_name> SHALLOW CLONE iceberg.\`/path/to/data\`;`} lang="sql" />
-
+    CREATE OR REPLACE TABLE <target_table_name> SHALLOW CLONE iceberg.`/path/to/data`;
+    ```
+  
   </TabItem>
 </Tabs>

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -5,16 +5,16 @@ sidebar:
   label: Welcome
 ---
 
-[Delta Lake](https://delta.io) is an [open source project](https://github.com/delta-incubator/delta-site) that enables building a [Lakehouse architecture](https://databricks.com/blog/2020/01/30/what-is-a-data-lakehouse.html) on top of [data lakes](https://databricks.com/discover/data-lakes/introduction). Delta Lake provides [ACID transactions](/concurrency-control/), scalable metadata handling, and unifies [streaming](/delta-streaming) and [batch](/delta-batch) data processing on top of existing data lakes, such as S3, ADLS, GCS, and HDFS.
+[Delta Lake](https://delta.io) is an [open source project](https://github.com/delta-io/delta) that enables building a [Lakehouse architecture](https://www.databricks.com/blog/2020/01/30/what-is-a-data-lakehouse.html) on top of [data lakes](https://www.databricks.com/discover/data-lakes). Delta Lake provides [ACID transactions](/concurrency-control), scalable metadata handling, and unifies [streaming](/delta-streaming) and [batch](/delta-batch) data processing on top of existing data lakes, such as S3, ADLS, GCS, and HDFS.
 
 Specifically, Delta Lake offers:
 
-- [ACID transactions](/concurrency-control/) on Spark: Serializable isolation levels ensure that readers never see inconsistent data.
+- [ACID transactions](/concurrency-control) on Spark: Serializable isolation levels ensure that readers never see inconsistent data.
 - Scalable metadata handling: Leverages Spark distributed processing power to handle all the metadata for petabyte-scale tables with billions of files at ease.
 - [Streaming](/delta-streaming) and [batch](/delta-batch) unification: A table in Delta Lake is a batch table as well as a streaming source and sink. Streaming data ingest, batch historic backfill, interactive queries all just work out of the box.
 - Schema enforcement: Automatically handles schema variations to prevent insertion of bad records during ingestion.
-- [Time travel](/delta-batch/#query-an-older-snapshot-of-a-table-time-travel): Data versioning enables rollbacks, full historical audit trails, and reproducible machine learning experiments.
-- [Upserts](/delta-update/#upsert-into-a-table-using-merge) and [deletes](/delta-update/#delete-from-a-table): Supports merge, update and delete operations to enable complex use cases like change-data-capture, slowly-changing-dimension (SCD) operations, streaming upserts, and so on.
+- [Time travel](/delta-batch#-deltatimetravel): Data versioning enables rollbacks, full historical audit trails, and reproducible machine learning experiments.
+- [Upserts](/delta-update#-delta-merge) and [deletes](/delta-update#-delta-delete): Supports merge, update and delete operations to enable complex use cases like change-data-capture, slowly-changing-dimension (SCD) operations, streaming upserts, and so on.
 - Vibrant connector ecosystem: Delta Lake has connectors read and write Delta tables from various data processing engines like Apache Spark, Apache Flink, Apache Hive, Apache Trino, AWS Athena, and more.
 
-To get started follow the [quickstart guide](/apache-spark-connector/quick) to learn how to use Delta Lake with Apache Spark.
+To get started follow the [quickstart guide](/quick-start) to learn how to use Delta Lake with Apache Spark.

--- a/src/content/docs/index.md
+++ b/src/content/docs/index.md
@@ -13,8 +13,8 @@ Specifically, Delta Lake offers:
 - Scalable metadata handling: Leverages Spark distributed processing power to handle all the metadata for petabyte-scale tables with billions of files at ease.
 - [Streaming](/delta-streaming) and [batch](/delta-batch) unification: A table in Delta Lake is a batch table as well as a streaming source and sink. Streaming data ingest, batch historic backfill, interactive queries all just work out of the box.
 - Schema enforcement: Automatically handles schema variations to prevent insertion of bad records during ingestion.
-- [Time travel](/delta-batch#-deltatimetravel): Data versioning enables rollbacks, full historical audit trails, and reproducible machine learning experiments.
-- [Upserts](/delta-update#-delta-merge) and [deletes](/delta-update#-delta-delete): Supports merge, update and delete operations to enable complex use cases like change-data-capture, slowly-changing-dimension (SCD) operations, streaming upserts, and so on.
+- [Time travel](/delta-batch#query-an-older-snapshot-of-a-table-time-travel): Data versioning enables rollbacks, full historical audit trails, and reproducible machine learning experiments.
+- [Upserts](/delta-update#upsert-into-a-table-using-merge) and [deletes](/delta-update#delete-from-a-table): Supports merge, update and delete operations to enable complex use cases like change-data-capture, slowly-changing-dimension (SCD) operations, streaming upserts, and so on.
 - Vibrant connector ecosystem: Delta Lake has connectors read and write Delta tables from various data processing engines like Apache Spark, Apache Flink, Apache Hive, Apache Trino, AWS Athena, and more.
 
 To get started follow the [quickstart guide](/quick-start) to learn how to use Delta Lake with Apache Spark.

--- a/src/content/docs/optimizations-oss/index.mdx
+++ b/src/content/docs/optimizations-oss/index.mdx
@@ -3,7 +3,7 @@ title: Optimizations
 description: Learn about the optimizations available with Delta Lake.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 import { Image } from "astro:assets";
 
 ## Optimize performance with file management

--- a/src/content/docs/presto-integration.mdx
+++ b/src/content/docs/presto-integration.mdx
@@ -23,7 +23,7 @@ You set up a Presto, Trino, or Athena to Delta Lake integration using the follow
 
 ### Step 1: Generate manifests of a Delta table using Apache Spark
 
-Using Spark [configured](quick-start.html#-set-up-as-with-delta) with Delta Lake, run any of the following commands on a Delta table at location `<path-to-delta-table>`:
+Using Spark [configured](/quick-start#set-up-apache-spark-with-delta-lake) with Delta Lake, run any of the following commands on a Delta table at location `<path-to-delta-table>`:
 
 <Tabs>
 <TabItem value="sql" label="SQL" default>
@@ -59,7 +59,7 @@ deltaTable.generate("symlink_format_manifest")
 </TabItem>
 </Tabs>
 
-See [Generate a manifest file](delta-utility.html#-delta-generate) for details.
+See [Generate a manifest file](delta-utility.html#generate-a-manifest-file) for details.
 
 The `generate` command generates manifest files at `<path-to-delta-table>/_symlink_format_manifest/`. In other words, the files in this directory will contain the names of the data files (that is, Parquet files) that should be read for reading a snapshot of the Delta table.
 
@@ -140,7 +140,7 @@ Depending on what storage system you are using for Delta tables, it is possible 
 
 ### Performance
 
-Very large numbers of files can hurt the performance of Presto, Trino, and Athena. Hence it is recommended that you [compact the files](best-practices.html#-delta-compact-files) of the table before generating the manifests. The number of files should not exceed 1000 (for the entire unpartitioned table or for each partition in a partitioned table).
+Very large numbers of files can hurt the performance of Presto, Trino, and Athena. Hence it is recommended that you [compact the files](/best-practices#compact-files) of the table before generating the manifests. The number of files should not exceed 1000 (for the entire unpartitioned table or for each partition in a partitioned table).
 
 ### Schema evolution
 

--- a/src/content/docs/quick-start.mdx
+++ b/src/content/docs/quick-start.mdx
@@ -1,11 +1,9 @@
 ---
-title: Quickstart
+title: Quick Start
 description: Learn how to get started quickly with Delta Lake.
 ---
 
-import { Tabs, TabItem } from "@astrojs/starlight/components";
-import { Code } from "@astrojs/starlight/components";
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 This guide helps you quickly explore the main features of Delta Lake. It provides code snippets that show how to read from and write to Delta tables from interactive, batch, and streaming queries.
 

--- a/src/content/docs/quick-start.mdx
+++ b/src/content/docs/quick-start.mdx
@@ -3,7 +3,7 @@ title: Quick Start
 description: Learn how to get started quickly with Delta Lake.
 ---
 
-import { Aside, Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 This guide helps you quickly explore the main features of Delta Lake. It provides code snippets that show how to read from and write to Delta tables from interactive, batch, and streaming queries.
 
@@ -14,10 +14,7 @@ Follow these instructions to set up Delta Lake with Spark. You can run the steps
 1. **Run interactively**: Start the Spark shell (Scala or Python) with Delta Lake and run the code snippets interactively in the shell.
 2. **Run as a project**: Set up a Maven or SBT project (Scala or Java) with Delta Lake, copy the code snippets into a source file, and run the project. Alternatively, you can use the [examples provided in the Github repository](https://github.com/delta-io/delta/tree/master/examples).
 
-<Aside
-  type="caution"
-  title="Important!"
->
+<Aside type="caution" title="Important!">
   For all of the following instructions, make sure to install the correct
   version of Spark or PySpark that is compatible with Delta Lake `4.0.0`. See the
   [release compatibility matrix](/releases) for details.
@@ -125,34 +122,43 @@ To create a Delta table, write a DataFrame out in the `delta` format. You can us
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`CREATE TABLE delta.\`/tmp/delta-table\` USING DELTA AS SELECT col1 as id FROM VALUES 0,1,2,3,4;`} lang="sql" />
+
+    ```sql
+    CREATE TABLE delta.`/tmp/delta-table` USING DELTA AS SELECT col1 as id FROM VALUES 0,1,2,3,4;
+    ```
+
   </TabItem>
 
-<TabItem label="Python">
-  <Code
-    code={`data = spark.range(0, 5)
-data.write.format("delta").save("/tmp/delta-table")`}
-    lang="python"
-  />
-</TabItem>
+  <TabItem label="Python">
+    
+    ```python
+    data = spark.range(0, 5)
+    data.write.format("delta").save("/tmp/delta-table")
+    ```
 
-<TabItem label="Scala">
-  <Code
-    code={`val data = spark.range(0, 5)
-data.write.format("delta").save("/tmp/delta-table")`}
-    lang="scala"
-  />
-</TabItem>
+  </TabItem>
+
+  <TabItem label="Scala">
+    
+    ```scala
+    val data = spark.range(0, 5)
+    data.write.format("delta").save("/tmp/delta-table")
+    ```
+
+  </TabItem>
 
   <TabItem label="Java">
-    <Code code={`import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
 
-SparkSession spark = ...   // create SparkSession
+    ```java
+    import org.apache.spark.sql.SparkSession;
+    import org.apache.spark.sql.Dataset;
+    import org.apache.spark.sql.Row;
 
-Dataset<Row> data = spark.range(0, 5);
-data.write().format("delta").save("/tmp/delta-table");`} lang="java" />
+    SparkSession spark = ...   // create SparkSession
+
+    Dataset<Row> data = spark.range(0, 5);
+    data.write().format("delta").save("/tmp/delta-table");
+    ```
 
   </TabItem>
 </Tabs>
@@ -171,28 +177,38 @@ You read data in your Delta table by specifying the path to the files: `"/tmp/de
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`SELECT * FROM delta.\`/tmp/delta-table\`;`} lang="sql" />
+
+    ```sql
+    SELECT * FROM delta.`/tmp/delta-table`;
+    ```
+
   </TabItem>
 
-<TabItem label="Python">
-  <Code
-    code={`df = spark.read.format("delta").load("/tmp/delta-table")
-df.show()`}
-    lang="python"
-  />
-</TabItem>
+  <TabItem label="Python">
+    
+    ```python
+    df = spark.read.format("delta").load("/tmp/delta-table")
+    df.show()
+    ```
 
-<TabItem label="Scala">
-  <Code
-    code={`val df = spark.read.format("delta").load("/tmp/delta-table")
-df.show()`}
-    lang="scala"
-  />
-</TabItem>
+  </TabItem>
+
+  <TabItem label="Scala">
+
+    ```scala
+    val df = spark.read.format("delta").load("/tmp/delta-table")
+    df.show()
+    ```
+
+  </TabItem>
 
   <TabItem label="Java">
-    <Code code={`Dataset<Row> df = spark.read().format("delta").load("/tmp/delta-table");
-df.show();`} lang="java" />
+  
+    ```java
+    Dataset<Row> df = spark.read().format("delta").load("/tmp/delta-table");
+    df.show();
+    ```
+  
   </TabItem>
 </Tabs>
 
@@ -204,29 +220,36 @@ Delta Lake supports several operations to modify tables using standard DataFrame
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`INSERT OVERWRITE delta.\`/tmp/delta-table\` SELECT col1 as id FROM VALUES 5,6,7,8,9;`} lang="sql" />
+  
+    ```sql
+    INSERT OVERWRITE delta.`/tmp/delta-table` SELECT col1 as id FROM VALUES 5,6,7,8,9;
+    ```
+  
   </TabItem>
+  <TabItem label="Python">
 
-<TabItem label="Python">
-  <Code
-    code={`data = spark.range(5, 10)
-data.write.format("delta").mode("overwrite").save("/tmp/delta-table")`}
-    lang="python"
-  />
-</TabItem>
+    ```python
+    data = spark.range(5, 10)
+    data.write.format("delta").mode("overwrite").save("/tmp/delta-table")
+    ```
 
-<TabItem label="Scala">
-  <Code
-    code={`val data = spark.range(5, 10)
-data.write.format("delta").mode("overwrite").save("/tmp/delta-table")
-df.show()`}
-    lang="scala"
-  />
-</TabItem>
+  </TabItem>
+  <TabItem label="Scala">
 
+    ```scala
+    val data = spark.range(5, 10)
+    data.write.format("delta").mode("overwrite").save("/tmp/delta-table")
+    df.show()
+    ```
+
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`Dataset<Row> data = spark.range(5, 10);
-data.write().format("delta").mode("overwrite").save("/tmp/delta-table");`} lang="java" />
+
+    ```java
+    Dataset<Row> data = spark.range(5, 10);
+    data.write().format("delta").mode("overwrite").save("/tmp/delta-table");
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -238,125 +261,134 @@ Delta Lake provides programmatic APIs to conditional update, delete, and merge (
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`-- Update every even value by adding 100 to it
-UPDATE delta.\`/tmp/delta-table\` SET id = id + 100 WHERE id % 2 == 0;
+  
+    ```sql
+    -- Update every even value by adding 100 to it
+    UPDATE delta.`/tmp/delta-table` SET id = id + 100 WHERE id % 2 == 0;
 
--- Delete every even value
-DELETE FROM delta.\`/tmp/delta-table\` WHERE id % 2 == 0;
+    -- Delete every even value
+    DELETE FROM delta.`/tmp/delta-table` WHERE id % 2 == 0;
 
--- Upsert (merge) new data
-CREATE TEMP VIEW newData AS SELECT col1 AS id FROM VALUES 1,3,5,7,9,11,13,15,17,19;
+    -- Upsert (merge) new data
+    CREATE TEMP VIEW newData AS SELECT col1 AS id FROM VALUES 1,3,5,7,9,11,13,15,17,19;
 
-MERGE INTO delta.\`/tmp/delta-table\` AS oldData
-USING newData
-ON oldData.id = newData.id
-WHEN MATCHED
-  THEN UPDATE SET id = newData.id
-WHEN NOT MATCHED
-  THEN INSERT (id) VALUES (newData.id);
+    MERGE INTO delta.`/tmp/delta-table` AS oldData
+    USING newData
+    ON oldData.id = newData.id
+    WHEN MATCHED
+      THEN UPDATE SET id = newData.id
+    WHEN NOT MATCHED
+      THEN INSERT (id) VALUES (newData.id);
 
-SELECT * FROM delta.\`/tmp/delta-table\`;`} lang="sql" />
-
+    SELECT * FROM delta.`/tmp/delta-table`;
+    ```
+  
   </TabItem>
-
   <TabItem label="Python">
-    <Code code={`from delta.tables import *
-from pyspark.sql.functions import *
 
-deltaTable = DeltaTable.forPath(spark, "/tmp/delta-table")
+    ```python
+    from delta.tables import *
+    from pyspark.sql.functions import *
 
-# Update every even value by adding 100 to it
-deltaTable.update(
-  condition = expr("id % 2 == 0"),
-  set = { "id": expr("id + 100") })
+    deltaTable = DeltaTable.forPath(spark, "/tmp/delta-table")
 
-# Delete every even value
-deltaTable.delete(condition = expr("id % 2 == 0"))
+    # Update every even value by adding 100 to it
+    deltaTable.update(
+      condition = expr("id % 2 == 0"),
+      set = { "id": expr("id + 100") })
 
-# Upsert (merge) new data
-newData = spark.range(0, 20)
+    # Delete every even value
+    deltaTable.delete(condition = expr("id % 2 == 0"))
 
-deltaTable.alias("oldData") \
-  .merge(
-    newData.alias("newData"),
-    "oldData.id = newData.id") \
-  .whenMatchedUpdate(set = { "id": col("newData.id") }) \
-  .whenNotMatchedInsert(values = { "id": col("newData.id") }) \
-  .execute()
+    # Upsert (merge) new data
+    newData = spark.range(0, 20)
 
-deltaTable.toDF().show()`} lang="python" />
+    deltaTable.alias("oldData") \
+      .merge(
+        newData.alias("newData"),
+        "oldData.id = newData.id") \
+      .whenMatchedUpdate(set = { "id": col("newData.id") }) \
+      .whenNotMatchedInsert(values = { "id": col("newData.id") }) \
+      .execute()
+
+    deltaTable.toDF().show()
+    ```
 
   </TabItem>
-
   <TabItem label="Scala">
-    <Code code={`import io.delta.tables._
-import org.apache.spark.sql.functions._
 
-val deltaTable = DeltaTable.forPath("/tmp/delta-table")
+    ```scala
+    import io.delta.tables._
+    import org.apache.spark.sql.functions._
 
-// Update every even value by adding 100 to it
-deltaTable.update(
-  condition = expr("id % 2 == 0"),
-  set = Map("id" -> expr("id + 100")))
+    val deltaTable = DeltaTable.forPath("/tmp/delta-table")
 
-// Delete every even value
-deltaTable.delete(condition = expr("id % 2 == 0"))
+    // Update every even value by adding 100 to it
+    deltaTable.update(
+      condition = expr("id % 2 == 0"),
+      set = Map("id" -> expr("id + 100")))
 
-// Upsert (merge) new data
-val newData = spark.range(0, 20).toDF
+    // Delete every even value
+    deltaTable.delete(condition = expr("id % 2 == 0"))
 
-deltaTable.as("oldData")
-  .merge(
-    newData.as("newData"),
-    "oldData.id = newData.id")
-  .whenMatched
-  .update(Map("id" -> col("newData.id")))
-  .whenNotMatched
-  .insert(Map("id" -> col("newData.id")))
-  .execute()
+    // Upsert (merge) new data
+    val newData = spark.range(0, 20).toDF
 
-deltaTable.toDF.show()`} lang="scala" />
+    deltaTable.as("oldData")
+      .merge(
+        newData.as("newData"),
+        "oldData.id = newData.id")
+      .whenMatched
+      .update(Map("id" -> col("newData.id")))
+      .whenNotMatched
+      .insert(Map("id" -> col("newData.id")))
+      .execute()
+
+    deltaTable.toDF.show()
+    ```
 
   </TabItem>
-
   <TabItem label="Java">
-    <Code code={`import io.delta.tables.*;
-import org.apache.spark.sql.functions;
-import java.util.HashMap;
 
-DeltaTable deltaTable = DeltaTable.forPath("/tmp/delta-table");
+    ```java
+    import io.delta.tables.*;
+    import org.apache.spark.sql.functions;
+    import java.util.HashMap;
 
-// Update every even value by adding 100 to it
-deltaTable.update(
-  functions.expr("id % 2 == 0"),
-  new HashMap<String, Column>() {{
-    put("id", functions.expr("id + 100"));
-  }}
-);
+    DeltaTable deltaTable = DeltaTable.forPath("/tmp/delta-table");
 
-// Delete every even value
-deltaTable.delete(condition = functions.expr("id % 2 == 0"));
+    // Update every even value by adding 100 to it
+    deltaTable.update(
+      functions.expr("id % 2 == 0"),
+      new HashMap<String, Column>() {{
+        put("id", functions.expr("id + 100"));
+      }}
+    );
 
-// Upsert (merge) new data
-Dataset<Row> newData = spark.range(0, 20).toDF();
+    // Delete every even value
+    deltaTable.delete(condition = functions.expr("id % 2 == 0"));
 
-deltaTable.as("oldData")
-  .merge(
-    newData.as("newData"),
-    "oldData.id = newData.id")
-  .whenMatched()
-  .update(
-    new HashMap<String, Column>() {{
-      put("id", functions.col("newData.id"));
-    }})
-  .whenNotMatched()
-  .insertExpr(
-    new HashMap<String, Column>() {{
-      put("id", functions.col("newData.id"));
-    }})
-  .execute();
+    // Upsert (merge) new data
+    Dataset<Row> newData = spark.range(0, 20).toDF();
 
-deltaTable.toDF().show();`} lang="java" />
+    deltaTable.as("oldData")
+      .merge(
+        newData.as("newData"),
+        "oldData.id = newData.id")
+      .whenMatched()
+      .update(
+        new HashMap<String, Column>() {{
+          put("id", functions.col("newData.id"));
+        }})
+      .whenNotMatched()
+      .insertExpr(
+        new HashMap<String, Column>() {{
+          put("id", functions.col("newData.id"));
+        }})
+      .execute();
+
+    deltaTable.toDF().show();
+    ```
 
   </TabItem>
 </Tabs>
@@ -371,28 +403,35 @@ You can query previous snapshots of your Delta table by using time travel. If yo
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
-    <Code code={`SELECT * FROM delta.\`/tmp/delta-table\` VERSION AS OF 0;`} lang="sql" />
+  
+    ```sql
+    SELECT * FROM delta.`/tmp/delta-table` VERSION AS OF 0;
+    ```
+  
   </TabItem>
+  <TabItem label="Python">
 
-<TabItem label="Python">
-  <Code
-    code={`df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
-df.show()`}
-    lang="python"
-  />
-</TabItem>
+    ```python
+    df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
+    df.show()
+    ```
 
-<TabItem label="Scala">
-  <Code
-    code={`val df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
-df.show()`}
-    lang="scala"
-  />
-</TabItem>
+  </TabItem>
+  <TabItem label="Scala">
 
+    ```scala
+    val df = spark.read.format("delta").option("versionAsOf", 0).load("/tmp/delta-table")
+    df.show()
+    ```
+
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`Dataset<Row> df = spark.read().format("delta").option("versionAsOf", 0).load("/tmp/delta-table");
-df.show();`} lang="java" />
+
+    ```java
+    Dataset<Row> df = spark.read().format("delta").option("versionAsOf", 0).load("/tmp/delta-table");
+    df.show();
+    ```
+
   </TabItem>
 </Tabs>
 
@@ -404,23 +443,29 @@ You can also write to a Delta table using Structured Streaming. The Delta Lake t
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`streamingDf = spark.readStream.format("rate").load()
-stream = streamingDf.selectExpr("value as id").writeStream.format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table")`} lang="python" />
+
+    ```python
+    streamingDf = spark.readStream.format("rate").load()
+    stream = streamingDf.selectExpr("value as id").writeStream.format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table")
+    ```
+
   </TabItem>
+  <TabItem label="Scala">
 
-<TabItem label="Scala">
-  <Code
-    code={`val streamingDf = spark.readStream.format("rate").load()
-val stream = streamingDf.select($"value" as "id").writeStream.format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table")`}
-    lang="scala"
-  />
-</TabItem>
+    ```scala
+    val streamingDf = spark.readStream.format("rate").load()
+    val stream = streamingDf.select($"value" as "id").writeStream.format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table")
+    ```
 
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`import org.apache.spark.sql.streaming.StreamingQuery;
 
-Dataset<Row> streamingDf = spark.readStream().format("rate").load();
-StreamingQuery stream = streamingDf.selectExpr("value as id").writeStream().format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table");`} lang="java" />
+    ```java
+    import org.apache.spark.sql.streaming.StreamingQuery;
+
+    Dataset<Row> streamingDf = spark.readStream().format("rate").load();
+    StreamingQuery stream = streamingDf.selectExpr("value as id").writeStream().format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table");
+    ```
 
   </TabItem>
 </Tabs>
@@ -443,17 +488,24 @@ While the stream is writing to the Delta table, you can also read from that tabl
 
 <Tabs syncKey="code-examples">
   <TabItem label="Python">
-    <Code code={`stream2 = spark.readStream.format("delta").load("/tmp/delta-table").writeStream.format("console").start()`} lang="python" />
+
+    ```python
+    stream2 = spark.readStream.format("delta").load("/tmp/delta-table").writeStream.format("console").start()
+    ```
+
   </TabItem>
+  <TabItem label="Scala">
 
-<TabItem label="Scala">
-  <Code
-    code={`val stream2 = spark.readStream.format("delta").load("/tmp/delta-table").writeStream.format("console").start()`}
-    lang="scala"
-  />
-</TabItem>
+    ```scala
+    val stream2 = spark.readStream.format("delta").load("/tmp/delta-table").writeStream.format("console").start()
+    ```
 
+  </TabItem>
   <TabItem label="Java">
-    <Code code={`StreamingQuery stream2 = spark.readStream().format("delta").load("/tmp/delta-table").writeStream().format("console").start();`} lang="java" />
+
+    ```java
+    StreamingQuery stream2 = spark.readStream().format("delta").load("/tmp/delta-table").writeStream().format("console").start();
+    ```
+
   </TabItem>
 </Tabs>

--- a/src/content/docs/quick-start.mdx
+++ b/src/content/docs/quick-start.mdx
@@ -72,36 +72,54 @@ If you want to build a project using Delta Lake binaries from Maven Central Repo
 
 You include Delta Lake in your Maven project by adding it as a dependency in your POM file. Delta Lake compiled with Scala 2.13.
 
-```xml
-<dependency>
-  <groupId>io.delta</groupId>
-  <artifactId>delta-spark_2.13</artifactId>
-  <version>4.0.0</version>
-</dependency>
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="XML" active>
+
+    ```xml
+    <dependency>
+      <groupId>io.delta</groupId>
+      <artifactId>delta-spark_2.13</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    ```
+  
+  </TabItem>
+</Tabs>
 
 #### SBT
 
 You include Delta Lake in your SBT project by adding the following line to your `build.sbt` file:
 
-```scala
-libraryDependencies += "io.delta" %% "delta-spark" % "4.0.0"
-```
+<Tabs syncKey="code-examples">
+  <TabItem label="Scala" active>
+
+    ```scala
+    libraryDependencies += "io.delta" %% "delta-spark" % "4.0.0"
+    ```
+  
+  </TabItem>
+</Tabs>
 
 #### Python
 
 To set up a Python project (for example, for unit testing), you can install Delta Lake using `pip install delta-spark==4.0.0` and then configure the SparkSession with the `configure_spark_with_delta_pip()` utility function in Delta Lake.
 
-```python
-import pyspark
-from delta import *
+<Tabs syncKey="code-examples">
+  <TabItem label="Python" active>
 
-builder = pyspark.sql.SparkSession.builder.appName("MyApp") \
-    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
-    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+    ```python
+    import pyspark
+    from delta import *
 
-spark = configure_spark_with_delta_pip(builder).getOrCreate()
-```
+    builder = pyspark.sql.SparkSession.builder.appName("MyApp") \
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    ```
+  
+  </TabItem>
+</Tabs>
 
 ## Create a table
 

--- a/src/content/docs/quick-start.mdx
+++ b/src/content/docs/quick-start.mdx
@@ -13,99 +13,96 @@ This guide helps you quickly explore the main features of Delta Lake. It provide
 
 Follow these instructions to set up Delta Lake with Spark. You can run the steps in this guide on your local machine in the following two ways:
 
-- **Run interactively**: Start the Spark shell (Scala or Python) with Delta Lake and run the code snippets interactively in the shell.
-
-- **Run as a project**: Set up a Maven or SBT project (Scala or Java) with Delta Lake, copy the code snippets into a source file, and run the project. Alternatively, you can use the [examples provided in the Github repository](https://github.com/delta-io/delta/tree/master/examples).
+1. **Run interactively**: Start the Spark shell (Scala or Python) with Delta Lake and run the code snippets interactively in the shell.
+2. **Run as a project**: Set up a Maven or SBT project (Scala or Java) with Delta Lake, copy the code snippets into a source file, and run the project. Alternatively, you can use the [examples provided in the Github repository](https://github.com/delta-io/delta/tree/master/examples).
 
 <Aside
   type="caution"
   title="Important!"
 >
   For all of the following instructions, make sure to install the correct
-  version of Spark or PySpark that is compatible with Delta Lake 3.3.0. See the
-  [release compatibility matrix](/releases/) for details.
+  version of Spark or PySpark that is compatible with Delta Lake `4.0.0`. See the
+  [release compatibility matrix](/releases) for details.
 </Aside>
 
 ### Prerequisite: set up Java
 
 As mentioned in the official Apache Spark installation instructions [here](https://spark.apache.org/docs/latest/index.html#downloading), make sure you have a valid Java version installed (8, 11, or 17) and that Java is configured correctly on your system using either the system `PATH` or `JAVA_HOME` environmental variable.
 
-<Aside
-  type="tip"
-  title="Windows Users"
->
-  Windows users should follow the instructions in this
-  [blog](https://phoenixnap.com/kb/install-spark-on-windows-10), making sure to
-  use the correct version of Apache Spark that is compatible with Delta Lake
-  `3.3.0`.
-</Aside>
+Windows users should follow the instructions in this [blog](https://phoenixnap.com/kb/install-spark-on-windows-10), making sure to use the correct version of Apache Spark that is compatible with Delta Lake `4.0.0`.
+
+### Set up interactive shell
 
 To use Delta Lake interactively within the Spark SQL, Scala, or Python shell, you need a local installation of Apache Spark. Depending on whether you want to use SQL, Python, or Scala, you can set up either the SQL, PySpark, or Spark shell, respectively.
 
-### Spark SQL Shell
+#### Spark SQL Shell
 
-<Tabs syncKey="code-examples">
-  <TabItem label="Spark SQL Shell">
-    Download the [compatible version](/releases/) of Apache Spark by following instructions from [Downloading Spark](https://spark.apache.org/downloads.html), either using `pip` or by downloading and extracting the archive and running `spark-sql` in the extracted directory.
+Download the [compatible version](/releases) of Apache Spark by following instructions from [Downloading Spark](https://spark.apache.org/downloads.html), either using `pip` or by downloading and extracting the archive and running `spark-sql` in the extracted directory.
 
-    <Code code={`bin/spark-sql --packages io.delta:delta-spark_2.12:3.3.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"`} lang="bash" />
+```bash
+bin/spark-sql --packages io.delta:delta-spark_2.13:4.0.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
+```
 
-  </TabItem>
+#### PySpark Shell
 
-  <TabItem label="PySpark Shell">
-    1. Install the PySpark version that is [compatible](/releases/) with the Delta Lake version by running the following:
+1. Install the PySpark version that is [compatible](/releases) with the Delta Lake version by running the following:
 
-    <Code code={`pip install pyspark==<compatible-spark-version>`} lang="bash" />
+    ```bash
+    pip install pyspark==<compatible-spark-version>
+    ```
+2. Run PySpark with the Delta Lake package and additional configurations:
 
-    2. Run PySpark with the Delta Lake package and additional configurations:
+    ```bash
+    pyspark --packages io.delta:delta-spark_2.13:4.0.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
+    ```
 
-    <Code code={`pyspark --packages io.delta:delta-spark_2.12:3.3.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"`} lang="bash" />
+#### Spark Scala Shell
 
-  </TabItem>
+Download the [compatible version](/releases/) of Apache Spark by following instructions from [Downloading Spark](https://spark.apache.org/downloads.html), either using `pip` or by downloading and extracting the archive and running `spark-shell` in the extracted directory.
 
-  <TabItem label="Spark Scala Shell">
-    Download the [compatible version](/releases/) of Apache Spark by following instructions from [Downloading Spark](https://spark.apache.org/downloads.html), either using `pip` or by downloading and extracting the archive and running `spark-shell` in the extracted directory.
+```bash
+bin/spark-shell --packages io.delta:delta-spark_2.13:4.0.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"
+```
 
-    <Code code={`bin/spark-shell --packages io.delta:delta-spark_2.12:3.3.0 --conf "spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension" --conf "spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog"`} lang="bash" />
-
-  </TabItem>
-</Tabs>
 ### Set up project
 
 If you want to build a project using Delta Lake binaries from Maven Central Repository, you can use the following Maven coordinates.
 
-<Tabs syncKey="code-examples">
-  <TabItem label="Maven">
-    You include Delta Lake in your Maven project by adding it as a dependency in your POM file. Delta Lake compiled with Scala 2.12.
+#### Maven
 
-    <Code code={`<dependency>
+You include Delta Lake in your Maven project by adding it as a dependency in your POM file. Delta Lake compiled with Scala 2.13.
 
+```xml
+<dependency>
   <groupId>io.delta</groupId>
-  <artifactId>delta-spark_2.12</artifactId>
-  <version>3.3.0</version>
-</dependency>`} lang="xml" />
-  </TabItem>
+  <artifactId>delta-spark_2.13</artifactId>
+  <version>4.0.0</version>
+</dependency>
+```
 
-  <TabItem label="SBT">
-    You include Delta Lake in your SBT project by adding the following line to your `build.sbt` file:
+#### SBT
 
-    <Code code={`libraryDependencies += "io.delta" %% "delta-spark" % "3.3.0"`} lang="scala" />
+You include Delta Lake in your SBT project by adding the following line to your `build.sbt` file:
 
-  </TabItem>
+```scala
+libraryDependencies += "io.delta" %% "delta-spark" % "4.0.0"
+```
 
-  <TabItem label="Python">
-    To set up a Python project (for example, for unit testing), you can install Delta Lake using `pip install delta-spark==3.3.0` and then configure the SparkSession with the `configure_spark_with_delta_pip()` utility function in Delta Lake.
+#### Python
 
-    <Code code={`import pyspark
+To set up a Python project (for example, for unit testing), you can install Delta Lake using `pip install delta-spark==4.0.0` and then configure the SparkSession with the `configure_spark_with_delta_pip()` utility function in Delta Lake.
 
-from delta import \*
+```python
+import pyspark
+from delta import *
 
-builder = pyspark.sql.SparkSession.builder.appName("MyApp") \\ .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \\ .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+builder = pyspark.sql.SparkSession.builder.appName("MyApp") \
+    .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
+    .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
 
-spark = configure_spark_with_delta_pip(builder).getOrCreate()`} lang="python" />
+spark = configure_spark_with_delta_pip(builder).getOrCreate()
+```
 
-  </TabItem>
-</Tabs>
 ## Create a table
 
 To create a Delta table, write a DataFrame out in the `delta` format. You can use existing Spark SQL code and change the format from `parquet`, `csv`, `json`, and so on, to `delta`.
@@ -136,14 +133,15 @@ data.write.format("delta").save("/tmp/delta-table")`}
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-SparkSession spark = ... // create SparkSession
+SparkSession spark = ...   // create SparkSession
 
-Dataset<Row> data = spark.range(0, 5); data.write().format("delta").save("/tmp/delta-table");`} lang="java" />
+Dataset<Row> data = spark.range(0, 5);
+data.write().format("delta").save("/tmp/delta-table");`} lang="java" />
 
   </TabItem>
 </Tabs>
 
-These operations create a new Delta table using the schema that was _inferred_ from your DataFrame. For the full set of options available when you create a new Delta table, see [Create a table](/delta-batch/#create-a-table) and [Write to a table](/delta-batch/#write-a-table).
+These operations create a new Delta table using the schema that was _inferred_ from your DataFrame. For the full set of options available when you create a new Delta table, see [Create a table](/delta-batch/#create-a-table) and [Write to a table](/delta-batch/#write-to-table).
 
 <Aside type="note">
   This quickstart uses local paths for Delta table locations. For configuring
@@ -153,7 +151,7 @@ These operations create a new Delta table using the schema that was _inferred_ f
 
 ## Read data
 
-You read data in your Delta table by specifying the path to the files: `/tmp/delta-table`:
+You read data in your Delta table by specifying the path to the files: `"/tmp/delta-table"`:
 
 <Tabs syncKey="code-examples">
   <TabItem label="SQL">
@@ -227,13 +225,21 @@ Delta Lake provides programmatic APIs to conditional update, delete, and merge (
     <Code code={`-- Update every even value by adding 100 to it
 UPDATE delta.\`/tmp/delta-table\` SET id = id + 100 WHERE id % 2 == 0;
 
--- Delete every even value DELETE FROM delta.\`/tmp/delta-table\` WHERE id % 2 == 0;
+-- Delete every even value
+DELETE FROM delta.\`/tmp/delta-table\` WHERE id % 2 == 0;
 
--- Upsert (merge) new data CREATE TEMP VIEW newData AS SELECT col1 AS id FROM VALUES 1,3,5,7,9,11,13,15,17,19;
+-- Upsert (merge) new data
+CREATE TEMP VIEW newData AS SELECT col1 AS id FROM VALUES 1,3,5,7,9,11,13,15,17,19;
 
-MERGE INTO delta.\`/tmp/delta-table\` AS oldData USING newData ON oldData.id = newData.id WHEN MATCHED THEN UPDATE SET id = newData.id WHEN NOT MATCHED THEN INSERT (id) VALUES (newData.id);
+MERGE INTO delta.\`/tmp/delta-table\` AS oldData
+USING newData
+ON oldData.id = newData.id
+WHEN MATCHED
+  THEN UPDATE SET id = newData.id
+WHEN NOT MATCHED
+  THEN INSERT (id) VALUES (newData.id);
 
-SELECT \* FROM delta.\`/tmp/delta-table\`;`} lang="sql" />
+SELECT * FROM delta.\`/tmp/delta-table\`;`} lang="sql" />
 
   </TabItem>
 
@@ -244,18 +250,23 @@ from pyspark.sql.functions import *
 deltaTable = DeltaTable.forPath(spark, "/tmp/delta-table")
 
 # Update every even value by adding 100 to it
-
-deltaTable.update( condition = expr("id % 2 == 0"), set = { "id": expr("id + 100") })
+deltaTable.update(
+  condition = expr("id % 2 == 0"),
+  set = { "id": expr("id + 100") })
 
 # Delete every even value
-
 deltaTable.delete(condition = expr("id % 2 == 0"))
 
 # Upsert (merge) new data
-
 newData = spark.range(0, 20)
 
-deltaTable.alias("oldData") \\ .merge( newData.alias("newData"), "oldData.id = newData.id") \\ .whenMatchedUpdate(set = { "id": col("newData.id") }) \\ .whenNotMatchedInsert(values = { "id": col("newData.id") }) \\ .execute()
+deltaTable.alias("oldData") \
+  .merge(
+    newData.alias("newData"),
+    "oldData.id = newData.id") \
+  .whenMatchedUpdate(set = { "id": col("newData.id") }) \
+  .whenNotMatchedInsert(values = { "id": col("newData.id") }) \
+  .execute()
 
 deltaTable.toDF().show()`} lang="python" />
 
@@ -267,13 +278,26 @@ import org.apache.spark.sql.functions._
 
 val deltaTable = DeltaTable.forPath("/tmp/delta-table")
 
-// Update every even value by adding 100 to it deltaTable.update( condition = expr("id % 2 == 0"), set = Map("id" -> expr("id + 100")))
+// Update every even value by adding 100 to it
+deltaTable.update(
+  condition = expr("id % 2 == 0"),
+  set = Map("id" -> expr("id + 100")))
 
-// Delete every even value deltaTable.delete(condition = expr("id % 2 == 0"))
+// Delete every even value
+deltaTable.delete(condition = expr("id % 2 == 0"))
 
-// Upsert (merge) new data val newData = spark.range(0, 20).toDF
+// Upsert (merge) new data
+val newData = spark.range(0, 20).toDF
 
-deltaTable.as("oldData") .merge( newData.as("newData"), "oldData.id = newData.id") .whenMatched .update(Map("id" -> col("newData.id"))) .whenNotMatched .insert(Map("id" -> col("newData.id"))) .execute()
+deltaTable.as("oldData")
+  .merge(
+    newData.as("newData"),
+    "oldData.id = newData.id")
+  .whenMatched
+  .update(Map("id" -> col("newData.id")))
+  .whenNotMatched
+  .insert(Map("id" -> col("newData.id")))
+  .execute()
 
 deltaTable.toDF.show()`} lang="scala" />
 
@@ -286,24 +310,44 @@ import java.util.HashMap;
 
 DeltaTable deltaTable = DeltaTable.forPath("/tmp/delta-table");
 
-// Update every even value by adding 100 to it deltaTable.update( functions.expr("id % 2 == 0"), new HashMap<String, Column>() {{
+// Update every even value by adding 100 to it
+deltaTable.update(
+  functions.expr("id % 2 == 0"),
+  new HashMap<String, Column>() {{
     put("id", functions.expr("id + 100"));
-  }} );
+  }}
+);
 
-// Delete every even value deltaTable.delete(condition = functions.expr("id % 2 == 0"));
+// Delete every even value
+deltaTable.delete(condition = functions.expr("id % 2 == 0"));
 
-// Upsert (merge) new data Dataset<Row> newData = spark.range(0, 20).toDF();
+// Upsert (merge) new data
+Dataset<Row> newData = spark.range(0, 20).toDF();
 
-deltaTable.as("oldData") .merge( newData.as("newData"), "oldData.id = newData.id") .whenMatched() .update( new HashMap<String, Column>() {{
+deltaTable.as("oldData")
+  .merge(
+    newData.as("newData"),
+    "oldData.id = newData.id")
+  .whenMatched()
+  .update(
+    new HashMap<String, Column>() {{
       put("id", functions.col("newData.id"));
-    }}) .whenNotMatched() .insertExpr( new HashMap<String, Column>() {{
+    }})
+  .whenNotMatched()
+  .insertExpr(
+    new HashMap<String, Column>() {{
       put("id", functions.col("newData.id"));
-    }}) .execute();
+    }})
+  .execute();
 
 deltaTable.toDF().show();`} lang="java" />
 
   </TabItem>
 </Tabs>
+
+You should see that some of the existing rows have been updated and new rows have been inserted.
+
+For more information on these operations, see [Table deletes, updates, and merges](/delta-update).
 
 ## Read older versions of data using time travel
 
@@ -336,7 +380,7 @@ df.show();`} lang="java" />
   </TabItem>
 </Tabs>
 
-You should see the first set of data, from before you overwrote it. Time travel takes advantage of the power of the Delta Lake transaction log to access data that is no longer in the table. Removing the version 0 option (or specifying version 1) would let you see the newer data again. For more information, see [Query an older snapshot of a table (time travel)](/delta-batch/#query-an-older-snapshot-of-a-table-time-travel).
+You should see the first set of data, from before you overwrote it. Time travel takes advantage of the power of the Delta Lake transaction log to access data that is no longer in the table. Removing the version `0` option (or specifying version `1`) would let you see the newer data again. For more information, see [Query an older snapshot of a table (time travel)](/delta-batch#query-an-older-snapshot-of-a-table-time-travel).
 
 ## Write a stream of data to a table
 
@@ -359,7 +403,8 @@ val stream = streamingDf.select($"value" as "id").writeStream.format("delta").op
   <TabItem label="Java">
     <Code code={`import org.apache.spark.sql.streaming.StreamingQuery;
 
-Dataset<Row> streamingDf = spark.readStream().format("rate").load(); StreamingQuery stream = streamingDf.selectExpr("value as id").writeStream().format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table");`} lang="java" />
+Dataset<Row> streamingDf = spark.readStream().format("rate").load();
+StreamingQuery stream = streamingDf.selectExpr("value as id").writeStream().format("delta").option("checkpointLocation", "/tmp/checkpoint").start("/tmp/delta-table");`} lang="java" />
 
   </TabItem>
 </Tabs>

--- a/src/content/docs/redshift-spectrum-integration.mdx
+++ b/src/content/docs/redshift-spectrum-integration.mdx
@@ -3,7 +3,7 @@ title: AWS Redshift Spectrum connector
 description: Learn how to set up an integration to enable you to read Delta tables from AWS Redshift.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Aside
   type="note"

--- a/src/content/docs/releases.mdx
+++ b/src/content/docs/releases.mdx
@@ -3,8 +3,6 @@ title: Releases
 description: Learn about Delta Lake releases.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
-
 ## Release notes
 
 The [GitHub releases page](https://github.com/delta-io/delta/releases/) describes features of each release.

--- a/src/content/docs/releases.mdx
+++ b/src/content/docs/releases.mdx
@@ -15,6 +15,7 @@ The following table lists Delta Lake versions and their compatible Apache Spark 
 
 | Delta Lake version | Apache Spark version    |
 | ------------------ | ----------------------- |
+| 4.0.x              | 4.0.x                   |
 | 3.3.x              | 3.5.x                   |
 | 3.2.x              | 3.5.x                   |
 | 3.1.x              | 3.5.x                   |

--- a/src/content/docs/snowflake-integration.mdx
+++ b/src/content/docs/snowflake-integration.mdx
@@ -3,7 +3,7 @@ title: Snowflake connector
 description: Learn how to set up an integration to enable you to read Delta tables from Snowflake.
 ---
 
-import { Tabs, TabItem, Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem, Steps } from "@astrojs/starlight/components";
 
 Visit the [Snowflake Delta Lake support](https://docs.snowflake.com/en/user-guide/tables-external-intro.html#delta-lake-support) documentation to use the connector.
 

--- a/src/content/docs/versioning.mdx
+++ b/src/content/docs/versioning.mdx
@@ -27,8 +27,10 @@ The following Delta Lake features break forward compatibility. Features are enab
 | Clustering | [Delta Lake 3.1.0](https://github.com/delta-io/delta/releases/tag/v3.1.0) | [Use liquid clustering for Delta tables](/delta-clustering/) |
 | Row Tracking | [Delta Lake 3.2.0](https://github.com/delta-io/delta/releases/tag/v3.2.0) | [Use row tracking for Delta tables](/row-tracking/) |
 | Type widening (Preview) | [Delta Lake 3.2.0](https://github.com/delta-io/delta/releases/tag/v3.2.0) | [Delta type widening](/delta-type-widening/) |
+| Type widening | [Delta Lake 4.0.0](https://github.com/delta-io/delta/releases/tag/v4.0.0) | [Delta type widening](/delta-type-widening/) |
 | Identity columns | [Delta Lake 3.3.0](https://github.com/delta-io/delta/releases/tag/v3.3.0) | [Use identity columns](/delta-batch/#use-identity-columns) |
-| In-Commit Timestamps | [Delta Lake 3.3.0](https://github.com/delta-io/delta/releases/tag/v3.3.0) | [Use identity columns](/delta-batch/#use-identity-columns) |
+| Variant Type | [Delta Lake 4.0.0](https://github.com/delta-io/delta/releases/tag/v4.0.0) | [Delta type widening](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#variant-data-type) |
+| Variant Shredding (Preview) | [Delta Lake 4.0.0](https://github.com/delta-io/delta/releases/tag/v4.0.0) | [Variant Shredding](https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-shredding.md) |
 
 ## What is a table protocol specification?
 
@@ -114,7 +116,9 @@ The following table shows minimum protocol versions required for Delta Lake feat
 | Vacuum Protocol Check | 7 | 3 | [Vacuum Protocol Check Spec](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#vacuum-protocol-check) |
 | Row Tracking | 7 | 3 | [Use row tracking for Delta tables](/delta-row-tracking/) |
 | Type widening (Preview) | 7 | 3 | [Delta type widening](/delta-type-widening/) |
-| In-Commit Timestamps | 7 | 3 | [In-Commit Timestamps Spec](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#in-commit-timestamps) |
+| Type widening | 7 | 3 | [Delta type widening](/delta-type-widening/) |
+| Variant Type | 7 | 3 | [Variant Type](https://github.com/delta-io/delta/blob/master/PROTOCOL.md#variant-data-type) |
+| Variant Shredding (Preview) | 7 | 3 | [Variant Shredding](https://github.com/delta-io/delta/blob/master/protocol_rfcs/variant-shredding.md) |
 
 ## Upgrading protocol versions
 

--- a/src/content/docs/versioning.mdx
+++ b/src/content/docs/versioning.mdx
@@ -3,7 +3,7 @@ title: How does Delta Lake manage feature compatibility?
 description: Learn how Delta table protocols are versioned.
 ---
 
-import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 Many Delta Lake optimizations require enabling Delta Lake features on a table. Delta Lake features are always backwards compatible, so tables written by a lower Delta Lake version can always be read and written by a higher Delta Lake version. Enabling some features breaks forward compatibility with workloads running in a lower Delta Lake version. For features that break forward compatibility, you must update all workloads that reference the upgraded tables to use a compliant Delta Lake version.
 


### PR DESCRIPTION
- Syncs docs with changes introduced in delta-io/delta@5d40e1829f4f5cb00686e24f7e0bbc94aad5e93b
- Removed `<Code />` as many of the code blocks were malformed and because we should prefer native markdown syntax whenever possible
- Cleaned up imports in MDX files
- Fixed a couple hash links